### PR TITLE
Feat: Expose number of routes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
   name: "swift-routing",
   platforms: [
     .iOS(.v17),
+    .macOS(.v13)
   ],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -37,7 +37,7 @@ public final class Router: BaseRouter, @unchecked Sendable {
   }
   /// current number of routes
   public var routeCount: Int {
-    path.count
+    path.count + (root != nil ? 1 : 0)
   }
   internal var present: Bool {
     sheet != nil || cover != nil

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -35,6 +35,10 @@ public final class Router: BaseRouter, @unchecked Sendable {
   public var isPresented: Bool {
     type.isPresented
   }
+  /// current number of routes
+  public var routeCount: Int {
+    path.count
+  }
   internal var present: Bool {
     sheet != nil || cover != nil
   }

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -37,7 +37,8 @@ public final class Router: BaseRouter, @unchecked Sendable {
   }
   /// current number of routes
   public var routeCount: Int {
-    path.count + (root != nil ? 1 : 0)
+    // +1 for root view
+    path.count + 1
   }
   internal var present: Bool {
     sheet != nil || cover != nil


### PR DESCRIPTION
I wanted to display a close button on root views but couldn't find a way to get the info to do so.

Exposing how many routes router is displaying/handling would help (and might be used for other things maybe). 

Example:

```swift
if router.isPresented && router.routeCount == 1 {
  CloseButton()
}
```

