### PR TITLE
Feat: Router present modifier

### DIFF
--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -94,10 +94,21 @@ public extension BaseRouter {
   ///
   /// - Parameter tabRoute: The `TabRoute` for which to find the corresponding `TabRouter`.
   /// - Returns: The `TabRouter` associated with the given tab, or `nil` if not found.
-  func tabRouter(for tabRoute: some TabRoute) -> TabRouter? {
+  @MainActor func tabRouter(for tabRoute: some TabRoute) -> TabRouter? {
     let tabRouters = children.compactMap { $0.value.value as? TabRouter }
 
     return tabRouters.first { type(of: $0.tab.wrapped) == type(of: tabRoute) }
+  }
+
+  /// Finds the `Router` instance managing a specific tab within a `TabRouter`.
+  ///
+  /// This method first locates the `TabRouter` corresponding to the provided `TabRoute`,
+  /// then searches inside it to find the `Router` managing that specific tab.
+  ///
+  /// - Parameter tabRoute: The `TabRoute` representing the tab to search for.
+  /// - Returns: The `Router` instance managing the specified tab, or `nil` if it is not found.
+  @MainActor func findRouterInTabRouter(for tabRoute: some TabRoute) -> Router? {
+    tabRouter(for: tabRoute)?.find(tab: tabRoute)
   }
 }
 

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -94,7 +94,7 @@ public extension BaseRouter {
   ///
   /// - Parameter tabRoute: The `TabRoute` for which to find the corresponding `TabRouter`.
   /// - Returns: The `TabRouter` associated with the given tab, or `nil` if not found.
-  @MainActor func tabRouter(for tabRoute: some TabRoute) -> TabRouter? {
+  func tabRouter(for tabRoute: some TabRoute) -> TabRouter? {
     let tabRouters = children.compactMap { $0.value.value as? TabRouter }
 
     return tabRouters.first { type(of: $0.tab.wrapped) == type(of: tabRoute) }

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -28,9 +28,14 @@ public final class Router: BaseRouter, @unchecked Sendable {
   public var rootID: UUID = UUID()
   @Published internal var root: AnyRoute
   @Published internal var path = NavigationPath()
-  @Published internal var sheet: AnyRoute?
-  @Published internal var cover: AnyRoute?
-  @Published internal var triggerClose: Bool = false
+  @Published internal var sheet: AnyRoute? {
+    didSet { present = sheet != nil }
+  }
+  @Published internal var cover: AnyRoute? {
+    didSet { present = cover != nil }
+  }
+  @Published private(set) var present: Bool = false
+  @Published internal private(set) var triggerClose: Bool = false
   public var currentRoute: AnyRoute
   public var isPresented: Bool {
     type.isPresented
@@ -39,9 +44,6 @@ public final class Router: BaseRouter, @unchecked Sendable {
   public var routeCount: Int {
     // +1 for root view
     path.count + 1
-  }
-  internal var present: Bool {
-    sheet != nil || cover != nil
   }
 
   // MARK: Configuration

--- a/Sources/SwiftRouting/ViewModifier/RouterPresentModifier.swift
+++ b/Sources/SwiftRouting/ViewModifier/RouterPresentModifier.swift
@@ -1,0 +1,28 @@
+//
+//  RouterPresentModifier.swift
+//  swift-routing
+//
+//  Created by Kévin Budain on 11/6/25.
+//
+
+import SwiftUI
+
+public struct RouterPresentModifier: ViewModifier {
+
+  let router: Router?
+  let perform: (Bool, Router) -> Void
+
+  public func body(content: Content) -> some View {
+    if let router {
+      content.onReceive(router.$present) { perform($0, router) }
+    } else {
+      content
+    }
+  }
+}
+
+public extension View {
+  func routerPresent(_ router: Router?, perform: @escaping (Bool, Router) -> Void) -> some View {
+    self.modifier(RouterPresentModifier(router: router, perform: perform))
+  }
+}


### PR DESCRIPTION
- add a modifier to listen `present` from `Router`
- add `findRouterInTabRouter` to find the rigth `Router` in a `TabRouter`