### PR TITLE
Feat: add tabRouter and update function

### DIFF
--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -86,7 +86,7 @@ public extension BaseRouter {
   ///
   /// - Parameter tab: The `TabRoute` to search for.
   /// - Returns: The `Router` managing the specified tab, if found.
-  @MainActor @discardableResult func find(tab: some TabRoute) -> Router? {
+  @MainActor @discardableResult func find(tab: any TabRoute) -> Router? {
     children.values.compactMap({ $0.value as? Router }).first(where: { $0.type == tab.type })
   }
 }
@@ -94,6 +94,13 @@ public extension BaseRouter {
 // MARK: - TabRouter
 
 public extension BaseRouter {
+
+  /// Finds and returns a `TabRouter` if there is only one `TabRouter` in children
+  var tabRouter: TabRouter? {
+    let tabRouters = children.compactMap { $0.value.value as? TabRouter }
+
+    return tabRouters.count == 1 ? tabRouters.first : nil
+  }
 
   /// Finds and returns a `TabRouter` instance associated with the given `TabRoute` type.
   ///

--- a/Sources/SwiftRouting/Router/TabRouter.swift
+++ b/Sources/SwiftRouting/Router/TabRouter.swift
@@ -75,9 +75,11 @@ extension TabRouter: @preconcurrency TabRouterModel {
   /// - Parameters:
   ///   - destination: The `Route` to push onto the stack.
   ///   - tab: The `TabRoute` where the route should be pushed.
-  @MainActor public func push(_ destination: some Route, in tab: some TabRoute) {
-    change(tab: tab)
-    find(tab: tab)?.push(destination)
+  @MainActor public func push(_ destination: some Route, in tab: (any TabRoute)?) {
+    if let tab {
+      change(tab: tab)
+    }
+    find(tab: tab ?? self.tab.wrapped)?.push(destination)
   }
 
   /// Presents a route as a modal sheet within a given tab.
@@ -85,9 +87,11 @@ extension TabRouter: @preconcurrency TabRouterModel {
   /// - Parameters:
   ///   - destination: The `Route` to present.
   ///   - tab: The `TabRoute` where the modal should be displayed.
-  @MainActor public func present(_ destination: some Route, in tab: some TabRoute) {
-    change(tab: tab)
-    find(tab: tab)?.present(destination)
+  @MainActor public func present(_ destination: some Route, in tab: (any TabRoute)?) {
+    if let tab {
+      change(tab: tab)
+    }
+    find(tab: tab ?? self.tab.wrapped)?.present(destination)
   }
 
   /// Presents a route as a full-screen cover within a given tab.
@@ -95,9 +99,11 @@ extension TabRouter: @preconcurrency TabRouterModel {
   /// - Parameters:
   ///   - destination: The `Route` to present as a cover.
   ///   - tab: The `TabRoute` where the cover should be displayed.
-  @MainActor public func cover(_ destination: some Route, in tab: some TabRoute) {
-    change(tab: tab)
-    find(tab: tab)?.cover(destination)
+  @MainActor public func cover(_ destination: some Route, in tab: (any TabRoute)?) {
+    if let tab {
+      change(tab: tab)
+    }
+    find(tab: tab ?? self.tab.wrapped)?.cover(destination)
   }
 }
 

--- a/Sources/SwiftRouting/Router/TabRouterModel.swift
+++ b/Sources/SwiftRouting/Router/TabRouterModel.swift
@@ -25,19 +25,34 @@ public protocol TabRouterModel: BaseRouterModel {
   /// - Parameters:
   ///   - destination: The `Route` to push onto the stack.
   ///   - tab: The `TabRoute` where the route should be pushed.
-  func push(_ destination: some Route, in tab: some TabRoute)
+  func push(_ destination: some Route, in tab: (any TabRoute)?)
 
   /// Presents a route as a modal sheet within a given tab.
   ///
   /// - Parameters:
   ///   - destination: The `Route` to present.
   ///   - tab: The `TabRoute` where the modal should be displayed.
-  func present(_ destination: some Route, in tab: some TabRoute)
+  func present(_ destination: some Route, in tab: (any TabRoute)?)
 
   /// Presents a route as a full-screen cover within a given tab.
   ///
   /// - Parameters:
   ///   - destination: The `Route` to present as a cover.
   ///   - tab: The `TabRoute` where the cover should be displayed.
-  func cover(_ destination: some Route, in tab: some TabRoute)
+  func cover(_ destination: some Route, in tab: (any TabRoute)?)
+}
+
+public extension TabRouterModel {
+
+  func push(_ destination: some Route) {
+    push(destination, in: nil)
+  }
+
+  func present(_ destination: some Route) {
+    present(destination, in: nil)
+  }
+
+  func cover(_ destination: some Route, in tab: (any TabRoute)?) {
+    cover(destination, in: nil)
+  }
 }


### PR DESCRIPTION
- add `tabRouter` optional if there is only on tabRouter in child
- update `push`, `present` and `cover` to push on in the currentTab without params 