### PR TITLE
impr(config): add Claude Code AI rules and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 
 # AI
 /.cursor
+/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md — swift-routing
+
+## Linear Ticket Workflow
+
+See `ai-rules/linear_flow.md` for the full workflow.
+
+---
+
+## Code Conventions
+
+- **Naming**: PascalCase for types, lowerCamelCase for properties/methods/enum cases
+- **Access control**: `public` only for exposed APIs, `private`/`internal` by default
+- **Concurrency**: `@MainActor` on main types, `@unchecked Sendable` for thread-safe classes
+- **Public classes**: `public final class`
+- **Doc comments**: `///` with Swift code examples on all public types and methods
+
+## Versioning
+
+See `ai-rules/versionning.md` for the full branch, commit, and PR conventions.
+
+## Tests
+
+See `ai-rules/testing.md` for the full rules.
+
+Summary:
+- Framework: Swift Testing (`import Testing`, `@Test`, `#expect`)
+- Structure: `struct` per domain, `enum` to group behaviors
+- Naming: `givenX_whenY_thenZ` or `stateDescription_return_result`
+- Command: `swift test`
+
+## Available Skills
+
+See `AGENTS.md` for the full skills system.
+
+Auto-load:
+- Test task → `swift-testing-expert` + `ai-rules/testing.md`
+- Navigation/routing task → `swift-routing`
+- Concurrency task → `swift-concurrency`
+- DocC documentation task → `swift-docc-documentation`
+
+## Linear Project
+
+- Workspace: `swift-routing`
+- Team: `Swift-Routing`
+- Project: `Plan d'amélioration`
+- Tickets: SWI-5 to SWI-19
+- Recommended order: T1 → T2 → D1 → D2 → E1 → E2 → rest

--- a/ai-rules/linear_flow.md
+++ b/ai-rules/linear_flow.md
@@ -1,0 +1,23 @@
+# Linear Flow (SwiftRouting)
+
+This file defines the workflow to follow when working on a Linear ticket.
+
+## Workflow
+
+1. **Read the ticket** — fetch title, description, labels via the Linear MCP
+2. **Create a branch** from `main` — see `ai-rules/versionning.md` for branch naming
+3. **Explore the code** before making any changes
+4. **Implement** following the project conventions
+5. **Run tests**: `swift test`
+6. **Commit** — see `ai-rules/versionning.md` for commit format
+7. **Push + create PR** — see `ai-rules/versionning.md` for PR format
+
+> Ticket states are updated automatically via the Linear ↔ GitHub integration.
+
+## Project Context
+
+- Workspace: `swift-routing`
+- Team: `Swift-Routing`
+- Project: `Plan d'amélioration`
+- Tickets: SWI-5 to SWI-19
+- Recommended order: T1 → T2 → D1 → D2 → E1 → E2 → rest

--- a/ai-rules/versionning.md
+++ b/ai-rules/versionning.md
@@ -1,0 +1,40 @@
+# Versioning Rules (SwiftRouting)
+
+This file defines branch, commit, and PR conventions for the project.
+
+## Branch Naming
+
+Format: `type/SWI-XX-short-title`
+
+| Type | Prefix |
+|---|---|
+| Feature | `feat/` |
+| Bug fix | `fix/` |
+| Improvement | `impr/` |
+| Documentation | `feat/` |
+
+Example: `feat/SWI-5-navigation-link-tests`
+
+## Commit Conventions
+
+Format: `short description`
+
+Example: `add NavigationLink extension tests`
+
+- No ticket number required.
+- No type prefix required.
+- Keep the message short and descriptive.
+
+## PR Conventions
+
+- **Title** format: `type(scope): [SWI-XX] description`
+- **Body** must follow this template:
+
+```
+**What**: Clear summary of what this PR accomplishes
+**Breaking Changes**: Highlight any API, public interface, or dependency changes
+```
+
+Types: `feat`, `fix`, `update`, `impr`, `revert`
+
+Example title: `feat(tests): [SWI-5] add NavigationLink extension tests`


### PR DESCRIPTION
**What**: Add Claude Code configuration and AI workflow rules to the repository

- Add `CLAUDE.md` — project instructions for Claude Code (conventions, skills, Linear project context)
- Add `ai-rules/linear_flow.md` — workflow to follow when working on a Linear ticket
- Add `ai-rules/versionning.md` — branch, commit, and PR naming conventions
- Update `.gitignore` — ignore `/.claude` (local Claude Code session data), unignore `CLAUDE.md` so it can be committed

**Breaking Changes**: None