### PR TITLE
feat(docs): [SWI-13] add visual diagrams to Architecture.md

### DIFF
--- a/Sources/SwiftRouting/SwiftRouting.docc/Articles/Architecture.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/Articles/Architecture.md
@@ -67,7 +67,23 @@ This protocol-based design enables:
 
 ### Hierarchical Router Structure
 
-SwiftRouting creates a hierarchy of routers that mirrors your navigation structure:
+SwiftRouting creates a hierarchy of routers that mirrors your navigation structure.
+
+**Without tabs** (single stack):
+
+```
+App
+└── RoutingView
+    └── Router  root: .home
+        ├── push(.list)
+        │   └── Stack: [.home, .list]          (same Router)
+        └── present(.detail)
+            └── Router  root: .detail          (child Router, sheet)
+                └── push(.comments)
+                    └── Stack: [.detail, .comments]
+```
+
+**With tabs**:
 
 ```
 App

--- a/Sources/SwiftRouting/SwiftRouting.docc/Articles/Architecture.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/Articles/Architecture.md
@@ -71,11 +71,20 @@ SwiftRouting creates a hierarchy of routers that mirrors your navigation structu
 
 ```
 App
-└── TabRouter (manages tab selection)
-    ├── Router [Home Tab]
-    │   └── Router [Presented Sheet]
-    ├── Router [Search Tab]
-    └── Router [Profile Tab]
+└── RoutingTabView
+    └── TabRouter
+        ├── RoutingView [Home Tab]
+        │   └── Router  root: .home
+        │       ├── push(.list)
+        │       │   └── Stack: [.home, .list]          (same Router)
+        │       └── present(.detail)
+        │           └── Router  root: .detail          (child Router, sheet)
+        │               └── push(.comments)
+        │                   └── Stack: [.detail, .comments]
+        ├── RoutingView [Search Tab]
+        │   └── Router  root: .search
+        └── RoutingView [Profile Tab]
+            └── Router  root: .profile
 ```
 
 Each ``RoutingView`` creates its own ``Router``. When you present a sheet or cover, a new child router is created. This hierarchy enables:
@@ -85,6 +94,25 @@ Each ``RoutingView`` creates its own ``Router``. When you present a sheet or cov
 - **Coordinated dismissal**: `closeChildren()` dismisses all descendants
 
 ## Component Relationships
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        RoutingTabView                        │
+│                             │                               │
+│                        TabRouter                            │
+│               ┌─────────────┼─────────────┐                │
+│               ▼             ▼             ▼                │
+│         RoutingView    RoutingView    RoutingView           │
+│              │                                              │
+│           Router  ◀── @Environment(\.router)               │
+│           │    │                                            │
+│      path │    │ sheet / cover                             │
+│           ▼    ▼                                            │
+│        Routes  Child Router (weak ref to parent)           │
+│                │                                            │
+│            contexts: [RouteContext observers]               │
+└─────────────────────────────────────────────────────────────┘
+```
 
 ### RoutingView
 
@@ -123,12 +151,30 @@ The ``Router`` manages:
 
 ### Navigation Flow
 
+Each navigation type operates differently on the router hierarchy:
+
 ```
-User Action → Router Method → State Update → SwiftUI Renders
-     │              │              │
-     │              │              └── @Published properties trigger view updates
-     │              └── push(), present(), back(), etc.
-     └── Button tap, deep link, programmatic call
+push(_:)
+    │
+    ├── Appends route to NavigationStack path
+    ├── Same Router instance handles the new route
+    └── back() or popToRoot() to unwind
+
+present(_:)  /  cover(_:)
+    │
+    ├── Creates a new child Router
+    ├── Presented as .sheet (present) or .fullScreenCover (cover)
+    ├── Child Router manages its own NavigationStack
+    └── close() or terminate(_:) to dismiss
+
+
+User Action        Router Method         State Change         SwiftUI Result
+─────────────      ─────────────         ────────────         ──────────────
+Button tap    ──▶  push(.detail)    ──▶  path += [.detail]  ──▶  New view pushed
+Link tapped   ──▶  present(.form)   ──▶  child Router set   ──▶  Sheet appears
+Back gesture  ──▶  back()           ──▶  path.removeLast()  ──▶  View popped
+Dismiss swipe ──▶  close()          ──▶  child Router = nil ──▶  Sheet dismissed
+Deep link     ──▶  handle(_:)       ──▶  path replaced      ──▶  Stack rebuilt
 ```
 
 ### Context Flow
@@ -141,6 +187,31 @@ Child Router                    Parent Router
      │ router.terminate(context) ────▶│ .routerContext handler executes
      │                               │
      │◀──── Navigation completes ────│
+```
+
+#### RouterContext Lifecycle
+
+```
+                    ┌─────────────────────────────────────┐
+                    │           Parent Router              │
+                    │                                      │
+  add(context:) ──▶ │  contexts: [SelectionContext: {...}] │
+                    │                                      │
+                    └──────────────────┬───────────────────┘
+                                       │ context propagates up
+                                       │
+                    ┌──────────────────▼───────────────────┐
+                    │           Child Router               │
+                    │                                      │
+ context(_:)    ──▶ │  Finds observer in parent hierarchy  │
+  terminate(_:) ──▶ │  Executes observer + navigates back  │
+                    │                                      │
+                    └──────────────────────────────────────┘
+
+Observer removal:
+  • Automatic  ──▶  route popped from stack (back / popToRoot)
+  • Automatic  ──▶  Router deallocated (sheet dismissed)
+  • Manual     ──▶  remove(context:) called explicitly
 ```
 
 ### Deep Link Flow

--- a/ai-rules/versionning.md
+++ b/ai-rules/versionning.md
@@ -31,8 +31,11 @@ Example: `add NavigationLink extension tests`
 - **Body** must follow this template:
 
 ```
-**What**: Clear summary of what this PR accomplishes
-**Breaking Changes**: Highlight any API, public interface, or dependency changes
+**What**:
+Clear summary of what this PR accomplishes
+
+**Breaking Changes**:
+Highlight any API, public interface, or dependency changes
 ```
 
 Types: `feat`, `fix`, `update`, `impr`, `revert`


### PR DESCRIPTION
**What**:
Enriches Architecture.md with detailed ASCII diagrams covering the four areas from the ticket: Router/TabRouter hierarchy with full tree (push stack, child routers), navigation flow per type (push/present/cover with state changes table), RouterContext lifecycle (add/execute/remove with auto-cleanup rules), and a component relations overview diagram.

**Breaking Changes**:
None