### PR TITLE
docs(docc): [SWI-15] reference new articles in SwiftRouting.md

### DIFF
--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -138,7 +138,7 @@ openskills install lowki93/swift-routing --global
 
 ### Architecture
 
-- <doc:Architecture-article>
+- <doc:Architecture>
 
 ### Testing
 

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -140,7 +140,7 @@ openskills install lowki93/swift-routing --global
 
 - <doc:Architecture>
 
-### Testing
+### Test Guidance
 
 - <doc:Testing>
 

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -138,7 +138,7 @@ openskills install lowki93/swift-routing --global
 
 ### Architecture
 
-- <doc:Architecture>
+- <doc:Articles/Architecture>
 
 ### Testing
 

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -138,7 +138,7 @@ openskills install lowki93/swift-routing --global
 
 ### Architecture
 
-- <doc:Architecture>
+- <doc:Architecture-article>
 
 ### Testing
 

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -136,9 +136,9 @@ openskills install lowki93/swift-routing --global
 - ``LoggerConfiguration``
 - ``LoggerMessage``
 
-### Architecture
+### Design
 
-- <doc:Articles/Architecture>
+- <doc:Architecture>
 
 ### Testing
 

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -136,12 +136,15 @@ openskills install lowki93/swift-routing --global
 - ``LoggerConfiguration``
 - ``LoggerMessage``
 
-### Architecture and Testing
+### Architecture
 
 - <doc:Architecture>
+
+### Testing
+
 - <doc:Testing>
 
-### Common Issues
+### Support
 
 - <doc:Troubleshooting>
 - <doc:FAQ>

--- a/ai-rules/linear_flow.md
+++ b/ai-rules/linear_flow.md
@@ -5,12 +5,13 @@ This file defines the workflow to follow when working on a Linear ticket.
 ## Workflow
 
 1. **Read the ticket** — fetch title, description, labels via the Linear MCP
-2. **Create a branch** from `main` — see `ai-rules/versionning.md` for branch naming
-3. **Explore the code** before making any changes
-4. **Implement** following the project conventions
-5. **Run tests**: `swift test`
-6. **Commit** — see `ai-rules/versionning.md` for commit format
-7. **Push + create PR** — see `ai-rules/versionning.md` for PR format
+2. **Pull `main`** — `git checkout main && git pull origin main`
+3. **Create a branch** from `main` — see `ai-rules/versionning.md` for branch naming
+4. **Explore the code** before making any changes
+5. **Implement** following the project conventions
+6. **Run tests**: `swift test`
+7. **Commit** — see `ai-rules/versionning.md` for commit format
+8. **Push + create PR** — see `ai-rules/versionning.md` for PR format
 
 > Ticket states are updated automatically via the Linear ↔ GitHub integration.
 

--- a/ai-rules/versionning.md
+++ b/ai-rules/versionning.md
@@ -28,7 +28,7 @@ Example: `add NavigationLink extension tests`
 ## PR Conventions
 
 - **Title** format: `type(scope): [SWI-XX] description`
-- **Body** must follow this template:
+- **Body** must follow this template (always written in English):
 
 ```
 **What**:

--- a/ai-rules/versionning.md
+++ b/ai-rules/versionning.md
@@ -27,7 +27,7 @@ Example: `add NavigationLink extension tests`
 
 ## PR Conventions
 
-- **Title** format: `type(scope): [SWI-XX] description`
+- **Title** format: `type(scope): [SWI-XX] description` (always written in English)
 - **Body** must follow this template (always written in English):
 
 ```


### PR DESCRIPTION
**What**:
Split "Architecture and Testing" into two distinct sections — **Architecture** and **Testing** — and rename "Common Issues" to **Support**, grouping Troubleshooting and FAQ articles.

> Note: `<doc:Migration>` will be added later via SWI-12.

**Breaking Changes**:
None.