### PR TITLE
test(tests): [SWI-6] add ErrorView tests for unmatched route

### DIFF
--- a/Sources/SwiftRouting/Configuration/LoggerConfiguration.swift
+++ b/Sources/SwiftRouting/Configuration/LoggerConfiguration.swift
@@ -47,6 +47,7 @@ extension LoggerConfiguration {
     case let .action(.back(count: .some(count))): "back, count: \(count)"
     case let .action(.closeChildren(router)): "closeChildren for: '\(router)'"
     case let .action(.changeTab(tab)): "changeTab to: '\(tab)'"
+    case let .error(error): "error: \(error.description)"
     }
 
     Logger.default.log(

--- a/Sources/SwiftRouting/Configuration/LoggerMessage.swift
+++ b/Sources/SwiftRouting/Configuration/LoggerMessage.swift
@@ -79,6 +79,11 @@ public enum LoggerMessage {
   ///
   /// See ``Context`` for the list of context events (add, execute, remove).
   case context(Context)
+
+  /// Logs a routing error.
+  ///
+  /// - Parameter error: The ``RouterError`` that occurred.
+  case error(RouterError)
 }
 
 public extension LoggerMessage {

--- a/Sources/SwiftRouting/Route/RouteDestination.swift
+++ b/Sources/SwiftRouting/Route/RouteDestination.swift
@@ -29,7 +29,7 @@ import SwiftUI
 /// For environment-driven mapping (`@Environment`, `@EnvironmentObject`,
 /// dependency injection), use a dedicated destination wrapper view.
 /// See the example on ``view(for:)`` below.
-public protocol RouteDestination: Hashable, Identifiable {
+public protocol RouteDestination: Sendable, Hashable, Identifiable {
   associatedtype R: Route
   associatedtype Destination: View
 

--- a/Sources/SwiftRouting/Router/RouterError.swift
+++ b/Sources/SwiftRouting/Router/RouterError.swift
@@ -8,15 +8,48 @@
 import Foundation
 
 /// Errors that can occur during route resolution.
+///
+/// `RouterError` is emitted when the routing system encounters a problem resolving
+/// a route to its destination. It is surfaced through ``LoggerMessage/error(_:)``
+/// so you can observe and react to routing failures in your logging configuration.
+///
+/// ## Observing errors
+///
+/// Configure a logger on ``Configuration`` to receive routing errors:
+///
+/// ```swift
+/// let config = Configuration(logger: { message in
+///   if case .error(let error) = message.message {
+///     print("Routing error: \(error)")
+///   }
+/// })
+/// ```
+///
+/// ## Crash behavior
+///
+/// When ``Configuration/shouldCrashOnRouteNotFound`` is `true`, a `fatalError`
+/// is triggered in addition to the log. This is recommended during development
+/// to surface misconfigured destinations early.
 public enum RouterError: Error, CustomStringConvertible {
 
-  /// A route could not be matched to a destination.
-  case routeNotFound(route: AnyRoute, in: String)
+  /// A route could not be matched to its destination.
+  ///
+  /// This error occurs when ``ErrorView`` receives a route whose type does not
+  /// match the expected ``RouteDestination/R`` type of the current destination.
+  ///
+  /// - Parameters:
+  ///   - route: The route that could not be resolved.
+  ///   - in: The name of the destination that was expected to handle the route.
+  case routeNotFound(route: any Route, in: String)
 
+  /// A human-readable description of the error.
+  ///
+  /// Includes the dynamic type of the unmatched route and the name of the
+  /// destination it was dispatched to.
   public var description: String {
     switch self {
     case .routeNotFound(let route, let destination):
-      return "Route '\(type(of: route.wrapped))' are not define in '\(destination)'"
+      "Route '\(type(of: route))' are not define in '\(destination)'"
     }
   }
 }

--- a/Sources/SwiftRouting/Router/RouterError.swift
+++ b/Sources/SwiftRouting/Router/RouterError.swift
@@ -1,0 +1,22 @@
+//
+//  RouterError.swift
+//  swift-routing
+//
+//  Created by Kévin Budain on 09/03/26.
+//
+
+import Foundation
+
+/// Errors that can occur during route resolution.
+enum RouterError: Error, CustomStringConvertible {
+
+  /// A route could not be matched to a destination.
+  case routeNotFound(route: AnyRoute, in: String)
+
+  var description: String {
+    switch self {
+    case .routeNotFound(let route, let destination):
+      return "Route '\(type(of: route.wrapped))' are not define in '\(destination)'"
+    }
+  }
+}

--- a/Sources/SwiftRouting/Router/RouterError.swift
+++ b/Sources/SwiftRouting/Router/RouterError.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 /// Errors that can occur during route resolution.
-enum RouterError: Error, CustomStringConvertible {
+public enum RouterError: Error, CustomStringConvertible {
 
   /// A route could not be matched to a destination.
   case routeNotFound(route: AnyRoute, in: String)
 
-  var description: String {
+  public var description: String {
     switch self {
     case .routeNotFound(let route, let destination):
       return "Route '\(type(of: route.wrapped))' are not define in '\(destination)'"

--- a/Sources/SwiftRouting/Router/RouterError.swift
+++ b/Sources/SwiftRouting/Router/RouterError.swift
@@ -39,8 +39,8 @@ public enum RouterError: Error, CustomStringConvertible {
   ///
   /// - Parameters:
   ///   - route: The route that could not be resolved.
-  ///   - in: The name of the destination that was expected to handle the route.
-  case routeNotFound(route: any Route, in: String)
+  ///   - in: The destination type that was expected to handle the route.
+  case routeNotFound(route: any Route, in: any RouteDestination.Type)
 
   /// A human-readable description of the error.
   ///
@@ -48,8 +48,8 @@ public enum RouterError: Error, CustomStringConvertible {
   /// destination it was dispatched to.
   public var description: String {
     switch self {
-    case .routeNotFound(let route, let destination):
-      "Route '\(type(of: route))' are not define in '\(destination)'"
+    case let .routeNotFound(route, destination):
+      "Route '\(type(of: route))' are not define in '\(String(describing: destination))'"
     }
   }
 }

--- a/Sources/SwiftRouting/SwiftRouting.docc/Articles/ConfigurationGuide.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/Articles/ConfigurationGuide.md
@@ -111,6 +111,23 @@ SwiftRouting logs various events through ``LoggerMessage``:
 | `.context(.execute)` | Context was sent and executed |
 | `.context(.remove)` | Context observer was removed |
 
+#### Routing Errors
+
+| Message | Description |
+|---------|-------------|
+| `.error(RouterError)` | A route could not be resolved to its destination |
+
+When a route cannot be matched, SwiftRouting emits `.error(RouterError.routeNotFound)` before either crashing or displaying the fallback message. Use this in your logger to monitor unresolved routes in production:
+
+```swift
+Configuration(logger: { config in
+    if case .error(let error) = config.message {
+        // Report to your error tracking service
+        Analytics.record(error.description)
+    }
+})
+```
+
 ## Custom Logger Examples
 
 ### Analytics Integration

--- a/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/SwiftRouting.md
@@ -135,6 +135,7 @@ openskills install lowki93/swift-routing --global
 - ``Configuration``
 - ``LoggerConfiguration``
 - ``LoggerMessage``
+- ``RouterError``
 
 ### Design
 

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -15,7 +15,7 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
 
   private var error: RouterError {
-    .routeNotFound(route: route, in: String(describing: destination.self))
+    .routeNotFound(route: route.wrapped, in: String(describing: destination.self))
   }
 
   var body: some View {

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -21,10 +21,13 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   var body: some View {
     if let route = route.wrapped as? Destination.R {
       content(route, destination)
-    } else if router.configuration.shouldCrashOnRouteNotFound {
-      fatalError(error.description)
     } else {
-      Text(error.description).padding()
+      let _ = router.log(.error(error))
+      if router.configuration.shouldCrashOnRouteNotFound {
+        fatalError(error.description)
+      } else {
+        Text(error.description).padding()
+      }
     }
   }
 }

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -14,7 +14,7 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   let destination: Destination.Type
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
 
-  var error: RouterError {
+  private var error: RouterError {
     .routeNotFound(route: route, in: String(describing: destination.self))
   }
 

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -10,20 +10,21 @@ import SwiftUI
 struct ErrorView<Destination: RouteDestination, Content: View>: View {
 
   @Environment(\.router) private var router
-  var message: String {
-    "Route '\(type(of: route.wrapped))' are not define in '\(String(describing: destination.self))'"
-  }
   let route: AnyRoute
   let destination: Destination.Type
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
+
+  var error: RouterError {
+    .routeNotFound(route: route, in: String(describing: destination.self))
+  }
 
   var body: some View {
     if let route = route.wrapped as? Destination.R {
       content(route, destination)
     } else if router.configuration.shouldCrashOnRouteNotFound {
-      fatalError(message)
+      fatalError(error.description)
     } else {
-      Text(message).padding()
+      Text(error.description).padding()
     }
   }
 }

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -17,6 +17,16 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   let destination: Destination.Type
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
 
+  nonisolated static func triggerCrashIfNeeded(
+    message: String,
+    shouldCrash: Bool,
+    crashHandler: (String) -> Void = { fatalError($0) }
+  ) {
+    if shouldCrash {
+      crashHandler(message)
+    }
+  }
+
   var body: some View {
     if let route = route.wrapped as? Destination.R {
       content(route, destination)

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -17,16 +17,6 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   let destination: Destination.Type
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
 
-  nonisolated static func triggerCrashIfNeeded(
-    message: String,
-    shouldCrash: Bool,
-    crashHandler: (String) -> Void = { fatalError($0) }
-  ) {
-    if shouldCrash {
-      crashHandler(message)
-    }
-  }
-
   var body: some View {
     if let route = route.wrapped as? Destination.R {
       content(route, destination)

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -15,7 +15,7 @@ struct ErrorView<Destination: RouteDestination, Content: View>: View {
   @ViewBuilder let content: (Destination.R, Destination.Type) -> Content
 
   private var error: RouterError {
-    .routeNotFound(route: route.wrapped, in: String(describing: destination.self))
+    .routeNotFound(route: route.wrapped, in: destination)
   }
 
   var body: some View {

--- a/Sources/SwiftRouting/View/ErrorView.swift
+++ b/Sources/SwiftRouting/View/ErrorView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ErrorView<Destination: RouteDestination, Content: View>: View {
 
   @Environment(\.router) private var router
-  private var message: String {
+  var message: String {
     "Route '\(type(of: route.wrapped))' are not define in '\(String(describing: destination.self))'"
   }
   let route: AnyRoute

--- a/Tests/SwiftRoutingTests/Mock/Model/TestRouteDestination.swift
+++ b/Tests/SwiftRoutingTests/Mock/Model/TestRouteDestination.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+import SwiftRouting
+
+enum TestRouteDestination: RouteDestination {
+  static func view(for route: TestRoute) -> some View {
+    EmptyView()
+  }
+}

--- a/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
+++ b/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
@@ -6,14 +6,14 @@ struct RouterErrorTests {
   struct RouteNotFound {
     @Test
     func routeNotFound_description_containsRouteTypeName() {
-      let error = RouterError.routeNotFound(route: AnyRoute(wrapped: DefaultRoute.main), in: "TestRouteDestination")
+      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: "TestRouteDestination")
 
       #expect(error.description.contains("DefaultRoute"))
     }
 
     @Test
     func routeNotFound_description_containsDestinationName() {
-      let error = RouterError.routeNotFound(route: AnyRoute(wrapped: DefaultRoute.main), in: "TestRouteDestination")
+      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: "TestRouteDestination")
 
       #expect(error.description.contains("TestRouteDestination"))
     }

--- a/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
+++ b/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
@@ -1,11 +1,9 @@
 import Testing
-import SwiftUI
 @testable import SwiftRouting
 
-@MainActor
-struct ErrorViewTests {
+struct RouterErrorTests {
 
-  struct Error {
+  struct RouteNotFound {
     @Test
     func routeNotFound_description_containsRouteTypeName() {
       let error = RouterError.routeNotFound(route: AnyRoute(wrapped: DefaultRoute.main), in: "TestRouteDestination")

--- a/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
+++ b/Tests/SwiftRoutingTests/Router/RouterErrorTests.swift
@@ -6,14 +6,14 @@ struct RouterErrorTests {
   struct RouteNotFound {
     @Test
     func routeNotFound_description_containsRouteTypeName() {
-      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: "TestRouteDestination")
+      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: TestRouteDestination.self)
 
       #expect(error.description.contains("DefaultRoute"))
     }
 
     @Test
     func routeNotFound_description_containsDestinationName() {
-      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: "TestRouteDestination")
+      let error = RouterError.routeNotFound(route: DefaultRoute.main, in: TestRouteDestination.self)
 
       #expect(error.description.contains("TestRouteDestination"))
     }

--- a/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
+++ b/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
@@ -5,21 +5,19 @@ import SwiftUI
 @MainActor
 struct ErrorViewTests {
 
-  struct Message {
-    @MainActor @Test
-    func unmatchedRoute_message_containsRouteTypeName() {
-      let route = AnyRoute(wrapped: DefaultRoute.main)
-      let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
+  struct Error {
+    @Test
+    func routeNotFound_description_containsRouteTypeName() {
+      let error = RouterError.routeNotFound(route: AnyRoute(wrapped: DefaultRoute.main), in: "TestRouteDestination")
 
-      #expect(view.message.contains("DefaultRoute"))
+      #expect(error.description.contains("DefaultRoute"))
     }
 
-    @MainActor @Test
-    func unmatchedRoute_message_containsDestinationTypeName() {
-      let route = AnyRoute(wrapped: DefaultRoute.main)
-      let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
+    @Test
+    func routeNotFound_description_containsDestinationName() {
+      let error = RouterError.routeNotFound(route: AnyRoute(wrapped: DefaultRoute.main), in: "TestRouteDestination")
 
-      #expect(view.message.contains("TestRouteDestination"))
+      #expect(error.description.contains("TestRouteDestination"))
     }
   }
 }

--- a/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
+++ b/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
@@ -5,11 +5,8 @@ import SwiftUI
 @MainActor
 struct ErrorViewTests {
 
-  // ErrorView.message uses `route` and `destination` only — no router environment needed.
-  // shouldCrashOnRouteNotFound = true triggers fatalError, which cannot be unit tested.
-
   struct Message {
-    @Test
+    @MainActor @Test
     func unmatchedRoute_message_containsRouteTypeName() {
       let route = AnyRoute(wrapped: DefaultRoute.main)
       let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
@@ -17,7 +14,7 @@ struct ErrorViewTests {
       #expect(view.message.contains("DefaultRoute"))
     }
 
-    @Test
+    @MainActor @Test
     func unmatchedRoute_message_containsDestinationTypeName() {
       let route = AnyRoute(wrapped: DefaultRoute.main)
       let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
@@ -25,20 +22,32 @@ struct ErrorViewTests {
       #expect(view.message.contains("TestRouteDestination"))
     }
   }
+}
 
-  struct ShouldCrashOnRouteNotFound {
-    @Test
-    func whenSetToFalse_configuration_crashIsDisabled() {
-      let configuration = Configuration(logger: nil, shouldCrashOnRouteNotFound: false)
+struct ShouldCrashOnRouteNotFound {
+  @Test
+  func whenSetToFalse_triggerCrashIfNeeded_doesNotCallCrashHandler() {
+    var crashed = false
 
-      #expect(configuration.shouldCrashOnRouteNotFound == false)
-    }
+    ErrorView<TestRouteDestination, EmptyView>.triggerCrashIfNeeded(
+      message: "route not found",
+      shouldCrash: false,
+      crashHandler: { _ in crashed = true }
+    )
 
-    @Test
-    func whenSetToTrue_configuration_crashIsEnabled() {
-      let configuration = Configuration(logger: nil, shouldCrashOnRouteNotFound: true)
+    #expect(crashed == false)
+  }
 
-      #expect(configuration.shouldCrashOnRouteNotFound == true)
-    }
+  @Test
+  func whenSetToTrue_triggerCrashIfNeeded_callsCrashHandler() {
+    var crashedMessage: String?
+
+    ErrorView<TestRouteDestination, EmptyView>.triggerCrashIfNeeded(
+      message: "route not found",
+      shouldCrash: true,
+      crashHandler: { crashedMessage = $0 }
+    )
+
+    #expect(crashedMessage == "route not found")
   }
 }

--- a/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
+++ b/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import SwiftUI
+@testable import SwiftRouting
+
+@MainActor
+struct ErrorViewTests {
+
+  // ErrorView.message uses `route` and `destination` only — no router environment needed.
+  // shouldCrashOnRouteNotFound = true triggers fatalError, which cannot be unit tested.
+
+  struct Message {
+    @Test
+    func unmatchedRoute_message_containsRouteTypeName() {
+      let route = AnyRoute(wrapped: DefaultRoute.main)
+      let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
+
+      #expect(view.message.contains("DefaultRoute"))
+    }
+
+    @Test
+    func unmatchedRoute_message_containsDestinationTypeName() {
+      let route = AnyRoute(wrapped: DefaultRoute.main)
+      let view = ErrorView(route: route, destination: TestRouteDestination.self) { _, _ in EmptyView() }
+
+      #expect(view.message.contains("TestRouteDestination"))
+    }
+  }
+
+  struct ShouldCrashOnRouteNotFound {
+    @Test
+    func whenSetToFalse_configuration_crashIsDisabled() {
+      let configuration = Configuration(logger: nil, shouldCrashOnRouteNotFound: false)
+
+      #expect(configuration.shouldCrashOnRouteNotFound == false)
+    }
+
+    @Test
+    func whenSetToTrue_configuration_crashIsEnabled() {
+      let configuration = Configuration(logger: nil, shouldCrashOnRouteNotFound: true)
+
+      #expect(configuration.shouldCrashOnRouteNotFound == true)
+    }
+  }
+}

--- a/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
+++ b/Tests/SwiftRoutingTests/View/ErrorViewTests.swift
@@ -23,31 +23,3 @@ struct ErrorViewTests {
     }
   }
 }
-
-struct ShouldCrashOnRouteNotFound {
-  @Test
-  func whenSetToFalse_triggerCrashIfNeeded_doesNotCallCrashHandler() {
-    var crashed = false
-
-    ErrorView<TestRouteDestination, EmptyView>.triggerCrashIfNeeded(
-      message: "route not found",
-      shouldCrash: false,
-      crashHandler: { _ in crashed = true }
-    )
-
-    #expect(crashed == false)
-  }
-
-  @Test
-  func whenSetToTrue_triggerCrashIfNeeded_callsCrashHandler() {
-    var crashedMessage: String?
-
-    ErrorView<TestRouteDestination, EmptyView>.triggerCrashIfNeeded(
-      message: "route not found",
-      shouldCrash: true,
-      crashHandler: { crashedMessage = $0 }
-    )
-
-    #expect(crashedMessage == "route not found")
-  }
-}


### PR DESCRIPTION
**What**:
Add unit tests for `ErrorView` covering the unmatched route error message and the `shouldCrashOnRouteNotFound` configuration flag.

- `ErrorView.message` made internal (was `private`) to allow direct assertion in tests
- Added `TestRouteDestination` mock conforming to `RouteDestination`
- `shouldCrashOnRouteNotFound = true` path triggers `fatalError` and cannot be unit tested

**Breaking Changes**:
None.