### PR TITLE
feat(docs): [SWI-20] add Medium article link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ For comprehensive documentation, tutorials, and API reference, visit the **[full
 | [Route Context](https://lowki93.github.io/swift-routing/0.2.0/documentation/swiftrouting/routecontextguide) | Pass data between routes |
 | [Migration](https://lowki93.github.io/swift-routing/0.2.0/documentation/swiftrouting/migration) | Migrate from native NavigationStack |
 
+## Articles
+
+- [Stop Fighting SwiftUI Navigation — A Type-Safe Approach with Swift Routing](https://medium.com/@budainkevin/stop-fighting-swiftui-navigation-a-type-safe-approach-with-swift-routing-7cbd328f0270)
+
 ## OpenSkills
 
 This project includes AI skills for assisted development via [OpenSkills](https://openskills.dev).


### PR DESCRIPTION
## Summary

- Add a new `## Articles` section in the README linking to the Medium article [Stop Fighting SwiftUI Navigation — A Type-Safe Approach with Swift Routing](https://medium.com/@budainkevin/stop-fighting-swiftui-navigation-a-type-safe-approach-with-swift-routing-7cbd328f0270)

## Test plan

- [ ] Verify the link renders correctly in the README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)