### PR TITLE
refactor: extract context and presentation into dedicated protocols and base types

### DIFF
--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -37,7 +37,7 @@ public class BaseRouter: ObservableObject, Identifiable {
     AnyRoute(wrapped: DefaultRoute.main)
   }
 
-  var pathCount: Int { 0 }
+  public var pathCount: Int { 0 }
 
   /// A dictionary containing child routers, stored weakly to avoid retain cycles.
   var children: [UUID: WeakContainer<BaseRouter>] = [:]

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -29,6 +29,16 @@ public class BaseRouter: ObservableObject, Identifiable {
 
   var contexts: Set<RouterContext> = []
 
+  /// The currently visible route managed by this router.
+  ///
+  /// Subclasses override this to return their active route.
+  /// Defaults to ``DefaultRoute/main`` for base instances.
+  public var currentRoute: AnyRoute {
+    AnyRoute(wrapped: DefaultRoute.main)
+  }
+
+  var pathCount: Int { 0 }
+
   /// A dictionary containing child routers, stored weakly to avoid retain cycles.
   var children: [UUID: WeakContainer<BaseRouter>] = [:]
 
@@ -74,6 +84,48 @@ public class BaseRouter: ObservableObject, Identifiable {
   ///   - message: The type of message being logged.
   func log(_ message: LoggerMessage) {
     configuration.logger?(LoggerConfiguration(message: message, router: self))
+  }
+}
+
+// MARK: - Context Management
+
+extension BaseRouter {
+
+  @MainActor public func add<R: RouteContext>(context object: R.Type, perform: @escaping (R) -> Void) {
+    let (inserted, element) = contexts.insert(
+      RouterContext(
+        router: self,
+        routerContext: object,
+        action: { [perform] in
+          guard let value = $0 as? R else { return }
+          perform(value)
+        }
+      )
+    )
+    if inserted {
+      log(.context(.add(element.route, context: element.routerContext)))
+    }
+  }
+
+  @MainActor public func remove<R: RouteContext>(context object: R.Type) {
+    for element in contexts.all(for: object, currentRoute: currentRoute.wrapped) {
+      contexts.remove(element)
+      log(.context(.remove(element.route, context: element.routerContext)))
+    }
+  }
+
+  @MainActor public func context(_ value: some RouteContext) {
+    let termination = Swift.type(of: value)
+
+    // Execute context in all parent routers (from root to direct parent)
+    var current = parent
+    while let router = current {
+      router.contexts.all(for: termination).forEach { $0.execute(value) }
+      current = router.parent
+    }
+
+    // Execute context in current router
+    contexts.all(for: termination).forEach { $0.execute(value) }
   }
 }
 

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -87,9 +87,9 @@ public class BaseRouter: ObservableObject, Identifiable {
   }
 }
 
-// MARK: - Context Management
+// MARK: - ContextModel
 
-extension BaseRouter {
+extension BaseRouter: @preconcurrency ContextModel {
 
   @MainActor public func add<R: RouteContext>(context object: R.Type, perform: @escaping (R) -> Void) {
     let (inserted, element) = contexts.insert(

--- a/Sources/SwiftRouting/Router/ContextModel.swift
+++ b/Sources/SwiftRouting/Router/ContextModel.swift
@@ -1,0 +1,48 @@
+//
+//  ContextModel.swift
+//  swift-routing
+//
+//  Created by Kévin Budain on 25/03/26.
+//
+
+import Foundation
+
+/// Defines context observation capabilities for router types.
+///
+/// `ContextModel` provides the ability to register, remove, and dispatch
+/// ``RouteContext`` observers. It is implemented by ``BaseRouter`` and
+/// inherited by all concrete router types, including ``Router`` and future
+/// router types such as `SplitRouter`.
+///
+/// Use these methods to pass data back from child routes or to react to
+/// navigation flow completions.
+public protocol ContextModel {
+
+  /// Registers a context observer for a specific ``RouteContext`` type.
+  ///
+  /// The closure is executed whenever a matching context is dispatched via
+  /// ``context(_:)`` or ``RouterModel/terminate(_:)``.
+  ///
+  /// > **Warning:** Capture class instances `[weak]` inside `perform` to
+  /// > avoid retain cycles.
+  ///
+  /// - Parameters:
+  ///   - object: The ``RouteContext`` type to observe.
+  ///   - perform: A closure executed when the context is triggered.
+  func add<R: RouteContext>(context object: R.Type, perform: @escaping (R) -> Void)
+
+  /// Removes context observers for a specific ``RouteContext`` type on the current route.
+  ///
+  /// Only observers registered on the router's current route are removed.
+  ///
+  /// - Parameter object: The ``RouteContext`` type to stop observing.
+  func remove<R: RouteContext>(context object: R.Type)
+
+  /// Dispatches a context value across the entire router hierarchy.
+  ///
+  /// Searches for matching observers in all parent routers (from root to
+  /// direct parent) and in the current router, then executes them.
+  ///
+  /// - Parameter value: The ``RouteContext`` to dispatch.
+  func context(_ value: some RouteContext)
+}

--- a/Sources/SwiftRouting/Router/ContextModel.swift
+++ b/Sources/SwiftRouting/Router/ContextModel.swift
@@ -11,8 +11,7 @@ import Foundation
 ///
 /// `ContextModel` provides the ability to register, remove, and dispatch
 /// ``RouteContext`` observers. It is implemented by ``BaseRouter`` and
-/// inherited by all concrete router types, including ``Router`` and future
-/// router types such as `SplitRouter`.
+/// inherited by all concrete router types built on ``BaseRouter``.
 ///
 /// Use these methods to pass data back from child routes or to react to
 /// navigation flow completions.

--- a/Sources/SwiftRouting/Router/ContextModel.swift
+++ b/Sources/SwiftRouting/Router/ContextModel.swift
@@ -18,6 +18,12 @@ import Foundation
 /// navigation flow completions.
 public protocol ContextModel {
 
+  /// The currently visible route managed by this router.
+  var currentRoute: AnyRoute { get }
+
+  /// The number of routes currently in the navigation path.
+  var pathCount: Int { get }
+
   /// Registers a context observer for a specific ``RouteContext`` type.
   ///
   /// The closure is executed whenever a matching context is dispatched via

--- a/Sources/SwiftRouting/Router/PresentableRouter.swift
+++ b/Sources/SwiftRouting/Router/PresentableRouter.swift
@@ -1,0 +1,73 @@
+//
+//  PresentableRouter.swift
+//  swift-routing
+//
+//  Created by Kévin Budain on 25/03/26.
+//
+
+import Combine
+import Foundation
+
+/// An intermediate router class that adds sheet and cover presentation capabilities.
+///
+/// `PresentableRouter` sits between ``BaseRouter`` and concrete router types such as
+/// ``Router`` and future types like `SplitRouter`. It owns the shared presentation
+/// state (`sheet`, `cover`, `triggerClose`) and provides default implementations of
+/// ``PresentationModel``, so subclasses get modal presentation for free.
+///
+/// You should not use `PresentableRouter` directly — use ``Router`` or a subclass instead.
+public class PresentableRouter: BaseRouter {
+
+  /// The route currently presented as a sheet, or `nil` if no sheet is shown.
+  @Published internal var sheet: AnyRoute? {
+    didSet {
+      guard oldValue != sheet else { return }
+      present.send((sheet != nil, self))
+    }
+  }
+
+  /// The route currently presented as a full-screen cover, or `nil` if none is shown.
+  @Published internal var cover: AnyRoute? {
+    didSet {
+      guard oldValue != cover else { return }
+      present.send((cover != nil, self))
+    }
+  }
+
+  /// Triggers dismissal of the current modal when set to `true`.
+  @Published internal var triggerClose: Bool = false
+
+  /// Indicates whether this router is presented modally.
+  ///
+  /// Defaults to `false`. Subclasses override this to reflect their presentation state.
+  public var isPresented: Bool { false }
+}
+
+// MARK: - PresentationModel
+
+extension PresentableRouter: @preconcurrency PresentationModel {
+
+  @MainActor public func present(_ destination: some Route, withStack: Bool) {
+    log(.navigation(from: currentRoute.wrapped, to: destination, type: .sheet(withStack: withStack)))
+    sheet = AnyRoute(wrapped: destination, inStack: withStack)
+  }
+
+  @MainActor public func cover(_ destination: some Route) {
+    log(.navigation(from: currentRoute.wrapped, to: destination, type: .cover))
+    cover = AnyRoute(wrapped: destination)
+  }
+
+  @MainActor public func close() {
+    guard isPresented else { return }
+    triggerClose = true
+    log(.action(.close))
+  }
+
+  @MainActor public func closeChildren() {
+    for child in children.values.compactMap({ $0.value as? PresentableRouter }) where child.isPresented {
+      log(.action(.closeChildren(child)))
+      sheet = nil
+      cover = nil
+    }
+  }
+}

--- a/Sources/SwiftRouting/Router/PresentableRouter.swift
+++ b/Sources/SwiftRouting/Router/PresentableRouter.swift
@@ -11,11 +11,11 @@ import Foundation
 /// An intermediate router class that adds sheet and cover presentation capabilities.
 ///
 /// `PresentableRouter` sits between ``BaseRouter`` and concrete router types such as
-/// ``Router`` and future types like `SplitRouter`. It owns the shared presentation
+/// ``Router`` and any concrete router type that needs modal presentation. It owns the shared presentation
 /// state (`sheet`, `cover`, `triggerClose`) and provides default implementations of
 /// ``PresentationModel``, so subclasses get modal presentation for free.
 ///
-/// You should not use `PresentableRouter` directly — use ``Router`` or a subclass instead.
+/// You should not use `PresentableRouter` directly — use ``Router`` instead.
 public class PresentableRouter: BaseRouter {
 
   /// The route currently presented as a sheet, or `nil` if no sheet is shown.

--- a/Sources/SwiftRouting/Router/PresentableRouter.swift
+++ b/Sources/SwiftRouting/Router/PresentableRouter.swift
@@ -64,10 +64,11 @@ extension PresentableRouter: @preconcurrency PresentationModel {
   }
 
   @MainActor public func closeChildren() {
-    for child in children.values.compactMap({ $0.value as? PresentableRouter }) where child.isPresented {
-      log(.action(.closeChildren(child)))
-      sheet = nil
-      cover = nil
-    }
+    let presentedChildren = children.values.compactMap({ $0.value as? PresentableRouter }).filter(\.isPresented)
+
+    guard !presentedChildren.isEmpty else { return }
+    presentedChildren.forEach { log(.action(.closeChildren($0))) }
+    sheet = nil
+    cover = nil
   }
 }

--- a/Sources/SwiftRouting/Router/PresentationModel.swift
+++ b/Sources/SwiftRouting/Router/PresentationModel.swift
@@ -1,0 +1,48 @@
+//
+//  PresentationModel.swift
+//  swift-routing
+//
+//  Created by Kévin Budain on 25/03/26.
+//
+
+import Foundation
+
+/// Defines modal and sheet presentation capabilities for router types.
+///
+/// `PresentationModel` is implemented by ``PresentableRouter`` and shared by all
+/// concrete router types that support sheet and cover presentation, such as
+/// ``Router`` and future router types like `SplitRouter`.
+///
+/// Use these methods to present routes modally or to dismiss the current router.
+public protocol PresentationModel {
+
+  /// Indicates whether this router is presented as a modal (sheet or cover).
+  var isPresented: Bool { get }
+
+  /// Presents a route as a modal sheet.
+  ///
+  /// - Parameters:
+  ///   - destination: The route to present.
+  ///   - withStack: If `true`, the sheet includes its own navigation stack.
+  func present(_ destination: some Route, withStack: Bool)
+
+  /// Presents a route as a full-screen cover.
+  ///
+  /// - Parameter destination: The route to present.
+  func cover(_ destination: some Route)
+
+  /// Dismisses the current modal router.
+  ///
+  /// No-op if the router is not presented.
+  func close()
+
+  /// Closes all child routers presented from this router.
+  func closeChildren()
+}
+
+public extension PresentationModel {
+  /// Presents a route as a modal sheet with a navigation stack.
+  func present(_ destination: some Route) {
+    present(destination, withStack: true)
+  }
+}

--- a/Sources/SwiftRouting/Router/PresentationModel.swift
+++ b/Sources/SwiftRouting/Router/PresentationModel.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// `PresentationModel` is implemented by ``PresentableRouter`` and shared by all
 /// concrete router types that support sheet and cover presentation, such as
-/// ``Router`` and future router types like `SplitRouter`.
+/// ``Router`` and any concrete router type built on ``PresentableRouter``.
 ///
 /// Use these methods to present routes modally or to dismiss the current router.
 public protocol PresentationModel {

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -57,7 +57,7 @@ public final class Router: BaseRouter, @unchecked Sendable {
     path.last ?? root
   }
 
-  override var pathCount: Int { path.count }
+  override public var pathCount: Int { path.count }
 
   /// Indicates whether this router is presented as a modal (sheet or cover).
   ///

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// ```swift
 /// @Environment(\.router) var router
 /// ```
-public final class Router: BaseRouter, @unchecked Sendable {
+public final class Router: PresentableRouter, @unchecked Sendable {
 
   static let defaultRouter: Router = Router(configuration: .default)
 
@@ -31,19 +31,6 @@ public final class Router: BaseRouter, @unchecked Sendable {
       removeContext(old: path, new: newValue)
     }
   }
-  @Published internal var sheet: AnyRoute? {
-    didSet {
-      guard oldValue != sheet else { return }
-      present.send((sheet != nil, self))
-    }
-  }
-  @Published internal var cover: AnyRoute? {
-    didSet {
-      guard oldValue != cover else { return }
-      present.send((cover != nil, self))
-    }
-  }
-  @Published internal var triggerClose: Bool = false
 
   /// The currently visible route in the navigation stack.
   ///
@@ -71,7 +58,7 @@ public final class Router: BaseRouter, @unchecked Sendable {
   ///   Button("Close") { router.close() }
   /// }
   /// ```
-  public var isPresented: Bool {
+  override public var isPresented: Bool {
     type.isPresented
   }
 
@@ -130,24 +117,9 @@ extension Router: @preconcurrency RouterModel {
     route(to: destination, type: .push)
   }
 
-  @MainActor public func present(_ destination: some Route, withStack: Bool) {
-    route(to: destination, type: .sheet(withStack: withStack))
-  }
-
-  @MainActor public func cover(_ destination: some Route) {
-    route(to: destination, type: .cover)
-  }
-
   @MainActor public func popToRoot() {
     path.removeAll()
     log(.action(.popToRoot))
-  }
-
-  @MainActor public func close() {
-    guard type.isPresented else { return }
-
-    triggerClose = true
-    log(.action(.close))
   }
 
   @MainActor public func back() {
@@ -174,17 +146,9 @@ extension Router: @preconcurrency RouterModel {
       back()
     }
   }
-
-  @MainActor public func closeChildren() {
-    for router in children.values.compactMap({ $0.value as? Router }) where router.isPresented {
-      log(.action(.closeChildren(router)))
-      sheet = nil
-      cover = nil
-    }
-  }
 }
 
-private extension Router  {
+private extension Router {
 
   @MainActor func route(to destination: some Route, type: RoutingType) {
     log(.navigation(from: currentRoute.wrapped, to: destination, type: type))

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -53,9 +53,11 @@ public final class Router: BaseRouter, @unchecked Sendable {
   /// ```swift
   /// print("Current route: \(router.currentRoute.name)")
   /// ```
-  public var currentRoute: AnyRoute {
+  override public var currentRoute: AnyRoute {
     path.last ?? root
   }
+
+  override var pathCount: Int { path.count }
 
   /// Indicates whether this router is presented as a modal (sheet or cover).
   ///
@@ -154,30 +156,6 @@ extension Router: @preconcurrency RouterModel {
     log(.action(.back()))
   }
 
-  @MainActor public func add<R: RouteContext>(context object: R.Type, perform: @escaping (R) -> Void) {
-    let (inserted, element) = contexts.insert(
-      RouterContext(
-        router: self,
-        routerContext: object,
-        action: { [perform] in
-          guard let value = $0 as? R else { return }
-          perform(value)
-        }
-      )
-    )
-    if inserted {
-      log(.context(.add(element.route, context: element.routerContext)))
-    }
-  }
-
-  @MainActor public func remove<R: RouteContext>(context object: R.Type) {
-    // Removes observers matching the context type only for the current route.
-    for element in contexts.all(for: object, currentRoute: currentRoute.wrapped) {
-      contexts.remove(element)
-      log(.context(.remove(element.route, context: element.routerContext)))
-    }
-  }
-
   @MainActor public func terminate(_ value: some RouteContext) {
     /// Execute all termination observers for the given context type (in both parent and child routers).
     context(value)
@@ -195,20 +173,6 @@ extension Router: @preconcurrency RouterModel {
     } else {
       back()
     }
-  }
-
-  @MainActor public func context(_ value: some RouteContext) {
-    let termination = Swift.type(of: value)
-
-    // Execute context in all parent routers (from root to direct parent)
-    var current = parent
-    while let router = current {
-      router.contexts.all(for: termination).forEach { $0.execute(value) }
-      current = router.parent
-    }
-
-    // Execute context in current router
-    contexts.all(for: termination).forEach { $0.execute(value) }
   }
 
   @MainActor public func closeChildren() {

--- a/Sources/SwiftRouting/Router/RouterContext.swift
+++ b/Sources/SwiftRouting/Router/RouterContext.swift
@@ -11,14 +11,14 @@ struct RouterContext: Hashable {
   let route: any Route
   let pathCount: Int
   let routerContext: any RouteContext.Type
-  private weak var router: Router?
+  private weak var router: BaseRouter?
   private let id: UUID
   private let action: (any RouteContext) -> Void
 
-  init(router: Router, routerContext: any RouteContext.Type, action: @escaping (any RouteContext) -> Void) {
+  init(router: BaseRouter, routerContext: any RouteContext.Type, action: @escaping (any RouteContext) -> Void) {
     self.id = router.id
     self.route = router.currentRoute.wrapped
-    self.pathCount = router.path.count
+    self.pathCount = router.pathCount
     self.routerContext = routerContext
     self.action = action
     self.router = router

--- a/Sources/SwiftRouting/Router/RouterModel.swift
+++ b/Sources/SwiftRouting/Router/RouterModel.swift
@@ -54,21 +54,6 @@ public protocol RouterModel: BaseRouterModel, ContextModel, PresentationModel {
   /// - Parameter destination: The `Route` to be pushed onto the stack.
   func push(_ destination: some Route)
 
-  /// Presents a route as a modal sheet.
-  ///
-  /// This method displays the specified route as a sheet, overlaying the current view.
-  ///
-  /// - Parameters:
-  ///   - destination: The `Route` to be presented as a sheet.
-  ///   - withStack: If `true`, the sheet includes its own navigation stack. If `false`, the route is presented without navigation capabilities.
-  func present(_ destination: some Route, withStack: Bool)
-
-  /// Presents a route as a full-screen cover.
-  ///
-  /// This method presents the specified route as a cover, taking over the entire screen.
-  /// - Parameter destination: The `Route` to be presented as a cover.
-  func cover(_ destination: some Route)
-
   /// Clears the entire navigation path, returning to the root.
   func popToRoot()
 

--- a/Sources/SwiftRouting/Router/RouterModel.swift
+++ b/Sources/SwiftRouting/Router/RouterModel.swift
@@ -35,7 +35,7 @@ import SwiftUI
 ///
 ///   let viewModel = ViewModel(router: router)
 /// ```
-public protocol RouterModel: BaseRouterModel {
+public protocol RouterModel: BaseRouterModel, ContextModel {
   /// Navigates to the given destination using its associated routingType.
   ///
   /// This method examines the `routingType` property of the route and performs the appropriate navigation action (push, sheet, cover, root, etc).
@@ -79,48 +79,9 @@ public protocol RouterModel: BaseRouterModel {
   /// Removes the last element from the navigation path, navigating back one step.
   func back()
 
-  /// Registers a context observer for a specific `RouteContext` type.
-  ///
-  /// Use this method to listen for context events triggered by `context(_:)` or `terminate(_:)`.
-  /// The closure will be executed whenever a matching context is dispatched, allowing you to
-  /// react to navigation flow completions or pass data between routes.
-  ///
-  /// > **Warning:**
-  /// > If you reference a class instance (e.g. a view model) inside the `perform` closure,
-  /// > capture it `[weak]` or `[unowned]` to prevent memory leaks.
-  ///
-  /// ## Example
-  /// ```swift
-  /// router.add(context: UserSelectionContext.self) { [weak self] context in
-  ///   self?.selectedUser = context.user
-  /// }
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - object: The `RouteContext` type to observe.
-  ///   - perform: A closure executed when the context is triggered.
-  func add<R: RouteContext>(context object: R.Type, perform: @escaping (R) -> Void)
-
-  /// Removes context observers for a specific `RouteContext` type on the current route.
-  ///
-  /// Use this method to stop listening for a particular context type, typically during cleanup
-  /// or when the observer is no longer needed.
-  /// Only observers registered on the router's current route are removed.
-  ///
-  /// - Parameter object: The `RouteContext` type to stop observing.
-  func remove<R: RouteContext>(context object: R.Type)
-
   /// End navigation flows that depend on a specific context, ensuring all related actions are completed before navigating back or closing.
   /// - Parameter value: `RouteContext` to execute before the back or close operation.
-  func terminate( _ value: some RouteContext)
-
-  /// Executes a navigation context action across the entire router hierarchy.
-  ///
-  /// This method searches for matching context observers in all parent routers (from root to direct parent)
-  /// and in the current router, then executes them with the provided value.
-  ///
-  /// - Parameter value: The `RouteContext` to execute across the router hierarchy.
-  func context(_ value: some RouteContext)
+  func terminate(_ value: some RouteContext)
 
   /// Closes all child routers presented from the parent router.
   func closeChildren()

--- a/Sources/SwiftRouting/Router/RouterModel.swift
+++ b/Sources/SwiftRouting/Router/RouterModel.swift
@@ -35,7 +35,7 @@ import SwiftUI
 ///
 ///   let viewModel = ViewModel(router: router)
 /// ```
-public protocol RouterModel: BaseRouterModel, ContextModel {
+public protocol RouterModel: BaseRouterModel, ContextModel, PresentationModel {
   /// Navigates to the given destination using its associated routingType.
   ///
   /// This method examines the `routingType` property of the route and performs the appropriate navigation action (push, sheet, cover, root, etc).
@@ -82,13 +82,4 @@ public protocol RouterModel: BaseRouterModel, ContextModel {
   /// End navigation flows that depend on a specific context, ensuring all related actions are completed before navigating back or closing.
   /// - Parameter value: `RouteContext` to execute before the back or close operation.
   func terminate(_ value: some RouteContext)
-
-  /// Closes all child routers presented from the parent router.
-  func closeChildren()
-}
-
-public extension RouterModel {
-  func present(_ destination: some Route) {
-    present(destination, withStack: true)
-  }
 }

--- a/Tests/SwiftRoutingTests/Router/TabRouterTests.swift
+++ b/Tests/SwiftRoutingTests/Router/TabRouterTests.swift
@@ -261,7 +261,7 @@ struct TabRouterTests {
     func deeplinkWithPushType_handleTabDeeplink_return_routePushedInTargetTab() {
       let expectedHomeRouter = attachRouter(in: tabRouter, tab: .home, root: .home)
       let expectedSettingsRouter = attachRouter(in: tabRouter, tab: .settings, root: .settings)
-      let deeplink = DeeplinkRoute(type: .push, route: TestRoute.details(id: "deeplink"))
+      let deeplink = DeeplinkRoute.push(TestRoute.details(id: "deeplink"))
       let tabDeeplink = TabDeeplink(tab: TestTabRoute.settings, deeplink: deeplink)
 
       tabRouter.handle(tabDeeplink: tabDeeplink)
@@ -274,9 +274,8 @@ struct TabRouterTests {
     @Test
     func deeplinkWithPath_handleTabDeeplink_return_pathAndRouteInTargetTab() {
       let expectedSettingsRouter = attachRouter(in: tabRouter, tab: .settings, root: .settings)
-      let deeplink = DeeplinkRoute(
-        type: .push,
-        route: TestRoute.details(id: "final"),
+      let deeplink = DeeplinkRoute.push(
+        TestRoute.details(id: "final"),
         path: [TestRoute.home, TestRoute.settings]
       )
       let tabDeeplink = TabDeeplink(tab: TestTabRoute.settings, deeplink: deeplink)
@@ -293,10 +292,9 @@ struct TabRouterTests {
     @Test
     func deeplinkWithRoot_handleTabDeeplink_return_rootUpdatedInTargetTab() {
       let expectedSettingsRouter = attachRouter(in: tabRouter, tab: .settings, root: .settings)
-      let deeplink = DeeplinkRoute(
+      let deeplink = DeeplinkRoute.push(
+        TestRoute.details(id: "after-root"),
         root: TestRoute.home,
-        type: .push,
-        route: TestRoute.details(id: "after-root")
       )
       let tabDeeplink = TabDeeplink(tab: TestTabRoute.settings, deeplink: deeplink)
 
@@ -310,7 +308,7 @@ struct TabRouterTests {
     @Test
     func deeplinkWithSheetType_handleTabDeeplink_return_sheetPresentedInTargetTab() {
       let expectedSettingsRouter = attachRouter(in: tabRouter, tab: .settings, root: .settings)
-      let deeplink = DeeplinkRoute(type: .sheet(withStack: true), route: TestRoute.details(id: "sheet"))
+      let deeplink = DeeplinkRoute.present(TestRoute.details(id: "sheet"))
       let tabDeeplink = TabDeeplink(tab: TestTabRoute.settings, deeplink: deeplink)
 
       tabRouter.handle(tabDeeplink: tabDeeplink)
@@ -326,7 +324,7 @@ struct TabRouterTests {
       expectedSettingsRouter.push(TestRoute.home)
       expectedSettingsRouter.push(TestRoute.details(id: "existing"))
       #expect(expectedSettingsRouter.path.count == 2)
-      let deeplink = DeeplinkRoute(type: .push, route: TestRoute.details(id: "new"))
+      let deeplink = DeeplinkRoute.push(TestRoute.details(id: "new"))
       let tabDeeplink = TabDeeplink(tab: TestTabRoute.settings, deeplink: deeplink)
 
       tabRouter.handle(tabDeeplink: tabDeeplink)
@@ -340,7 +338,7 @@ struct TabRouterTests {
     func tabRouterDoesNotExistForTab_handleTabDeeplink_return_tabChangedOnly() {
       let tabDeeplink = TabDeeplink(
         tab: TestTabRoute.settings,
-        deeplink: DeeplinkRoute(type: .push, route: TestRoute.details(id: "orphan"))
+        deeplink: DeeplinkRoute.push(TestRoute.details(id: "orphan"))
       )
 
       tabRouter.handle(tabDeeplink: tabDeeplink)


### PR DESCRIPTION
## Summary

- Extract context management (`add`, `remove`, `context`) from `Router` into `BaseRouter`, backed by a new `ContextModel` protocol
- Introduce `PresentableRouter` between `BaseRouter` and `Router` to hold shared sheet/cover presentation state and logic, backed by a new `PresentationModel` protocol
- `RouterModel` now inherits from both `ContextModel` and `PresentationModel`
- `RouterContext` decoupled from `Router` — now depends on `BaseRouter` via `currentRoute` and `pathCount`

## Test plan

- [ ] All 141 existing tests pass
- [ ] `closeChildren` correctly nils the parent's `sheet`/`cover` bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)