### PR TITLE
feat: (onTabReselected) add onTabReselected modifier to RoutingTabView and fix double-write bug

### DIFF
--- a/.skills/swift-routing/SKILL.md
+++ b/.skills/swift-routing/SKILL.md
@@ -66,6 +66,8 @@ Then continue by use case:
   - Audit closure captures in `add(context:perform:)` and `.routerContext`.
 - "Deep link resolves but does not navigate"
   - Validate route mapping, destination type, and target router (`router` vs `tabRouter`).
+- "Need to react to tab reselection (e.g. scroll to top)"
+  - Use `.onTabReselected(tab:)` from any child view; `popToRoot` fires first, then the handler.
 
 ## TODO (This Skill)
 

--- a/.skills/swift-routing/references/tab-router.md
+++ b/.skills/swift-routing/references/tab-router.md
@@ -217,6 +217,26 @@ tabRouter.push(.profile, in: .profile)
 tabRouter.popToRoot(in: .profile)
 ```
 
+## Reacting to Tab Reselection
+
+Use `.onTabReselected` from any child view to run code when the user taps the already-selected tab.
+`popToRoot` always fires first; the handler is called after.
+
+```swift
+struct HomeView: View {
+  var body: some View {
+    ScrollView { /* ... */ }
+      .onTabReselected(HomeTab.home) {
+        // e.g. scroll to top
+      }
+  }
+}
+```
+
+- Works with both `RoutingTabView` and native `TabView + .tabToRoot`.
+- Handler fires only when the reselected tab matches the tab argument.
+- No-op if used outside a tab context.
+
 ## Best Practices
 
 - Keep one `RoutingView` per tab.

--- a/Examples/SwiftRoutingDemo/SwiftRoutingDemo/Screens/HomeScreen.swift
+++ b/Examples/SwiftRoutingDemo/SwiftRoutingDemo/Screens/HomeScreen.swift
@@ -39,6 +39,9 @@ struct HomeScreen: View {
     .routerPresent {
       print("=== HomeScreen : ", $0, $1)
     }
+    .onTabReselected(HomeTab.home) {
+      print("=== HomeTab.home")
+    }
   }
 }
 

--- a/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
+++ b/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
@@ -12,21 +12,21 @@ public extension Binding where Value: TabRoute {
   /// Clears the navigation path of the specified tab, with optional reselection handling.
   ///
   /// This function locates the router associated with the current tab and resets its navigation path.
-  /// - If the selected tab matches the new value, it triggers `popToRoot()` then calls `onReselected` if provided.
+  /// - If the selected tab matches the new value, it calls `popToRoot()`, fires
+  ///   `TabRouter.tabReselected`, then calls `onReselected` if provided.
   /// - Otherwise, it updates the tab selection.
   ///
   /// - Parameters:
   ///   - tab: A binding to the current tab.
   ///   - router: The router managing the tabview.
-  ///   - onReselected: An optional closure invoked when the user taps the already-selected tab.
-  ///     When provided, replaces the default `popToRoot()` behavior. Always called on the main actor.
+  ///   - onReselected: An optional closure invoked when the user taps the already-selected tab,
+  ///     after `popToRoot()` has been called. For child-view use cases, prefer observing
+  ///     `TabRouter.tabReselected` via ``onTabReselected(_:perform:)`` instead.
   /// - Returns: A binding that updates the tab and clears its navigation stack when reselected.
   ///
   /// ## Usage
   /// ```swift
-  /// TabView(selection: .tabToRoot(for: $tab, in: router, onReselected: { tab in
-  ///   scrollToTop(for: tab)
-  /// })) {
+  /// TabView(selection: .tabToRoot(for: $tab, in: router)) {
   ///   // tab content
   /// }
   /// ```
@@ -40,6 +40,9 @@ public extension Binding where Value: TabRoute {
       set: {
         if tab.wrappedValue == $0 {
           router.find(tab: $0)?.popToRoot()
+          if let tabRouter = router as? TabRouter {
+            tabRouter.tabReselected.send(AnyTabRoute(wrapped: $0))
+          }
           onReselected?($0)
         } else {
           tab.wrappedValue = $0

--- a/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
+++ b/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
@@ -9,21 +9,43 @@ import SwiftUI
 
 public extension Binding where Value: TabRoute {
 
-  /// Clears the navigation path of the specified tab.
+  /// Clears the navigation path of the specified tab, with optional reselection handling.
   ///
   /// This function locates the router associated with the current tab and resets its navigation path.
-  /// If the selected tab is the same as the new value, it triggers `popToRoot()`, otherwise, it updates the tab selection.
+  /// - If the selected tab matches the new value and `onReselected` is `nil`, it triggers `popToRoot()`.
+  /// - If the selected tab matches the new value and `onReselected` is provided, it calls `onReselected`
+  ///   instead of `popToRoot()`, giving full control over the reselection behavior.
+  /// - Otherwise, it updates the tab selection.
   ///
   /// - Parameters:
   ///   - tab: A binding to the current tab.
   ///   - router: The router managing the tabview.
+  ///   - onReselected: An optional closure invoked when the user taps the already-selected tab.
+  ///     When provided, replaces the default `popToRoot()` behavior. Always called on the main actor.
   /// - Returns: A binding that updates the tab and clears its navigation stack when reselected.
-  @MainActor static func tabToRoot(for tab: Binding<Value>, in router: BaseRouter) -> Binding<Value> {
+  ///
+  /// ## Usage
+  /// ```swift
+  /// TabView(selection: .tabToRoot(for: $tab, in: router, onReselected: { tab in
+  ///   scrollToTop(for: tab)
+  /// })) {
+  ///   // tab content
+  /// }
+  /// ```
+  @MainActor static func tabToRoot(
+    for tab: Binding<Value>,
+    in router: BaseRouter,
+    onReselected: ((Value) -> Void)? = nil
+  ) -> Binding<Value> {
     Binding(
       get: { tab.wrappedValue },
       set: {
         if tab.wrappedValue == $0 {
-          router.find(tab: $0)?.popToRoot()
+          if let onReselected {
+            onReselected($0)
+          } else {
+            router.find(tab: $0)?.popToRoot()
+          }
         } else {
           tab.wrappedValue = $0
           if let tabRouter = router as? TabRouter {

--- a/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
+++ b/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
@@ -12,9 +12,7 @@ public extension Binding where Value: TabRoute {
   /// Clears the navigation path of the specified tab, with optional reselection handling.
   ///
   /// This function locates the router associated with the current tab and resets its navigation path.
-  /// - If the selected tab matches the new value and `onReselected` is `nil`, it triggers `popToRoot()`.
-  /// - If the selected tab matches the new value and `onReselected` is provided, it calls `onReselected`
-  ///   instead of `popToRoot()`, giving full control over the reselection behavior.
+  /// - If the selected tab matches the new value, it triggers `popToRoot()` then calls `onReselected` if provided.
   /// - Otherwise, it updates the tab selection.
   ///
   /// - Parameters:
@@ -41,11 +39,8 @@ public extension Binding where Value: TabRoute {
       get: { tab.wrappedValue },
       set: {
         if tab.wrappedValue == $0 {
-          if let onReselected {
-            onReselected($0)
-          } else {
-            router.find(tab: $0)?.popToRoot()
-          }
+          router.find(tab: $0)?.popToRoot()
+          onReselected?($0)
         } else {
           tab.wrappedValue = $0
           if let tabRouter = router as? TabRouter {

--- a/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
+++ b/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
@@ -40,9 +40,7 @@ public extension Binding where Value: TabRoute {
       set: {
         if tab.wrappedValue == $0 {
           router.find(tab: $0)?.popToRoot()
-          if let tabRouter = router as? TabRouter {
-            tabRouter.tabReselected.send(AnyTabRoute(wrapped: $0))
-          }
+          router.tabReselected.send(AnyTabRoute(wrapped: $0))
           onReselected?($0)
         } else {
           tab.wrappedValue = $0

--- a/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
+++ b/Sources/SwiftRouting/Extension/Binding+TabRoute.swift
@@ -12,16 +12,13 @@ public extension Binding where Value: TabRoute {
   /// Clears the navigation path of the specified tab, with optional reselection handling.
   ///
   /// This function locates the router associated with the current tab and resets its navigation path.
-  /// - If the selected tab matches the new value, it calls `popToRoot()`, fires
-  ///   `TabRouter.tabReselected`, then calls `onReselected` if provided.
+  /// - If the selected tab matches the new value, it calls `popToRoot()` and fires
+  ///   `TabRouter.tabReselected`.
   /// - Otherwise, it updates the tab selection.
   ///
   /// - Parameters:
   ///   - tab: A binding to the current tab.
   ///   - router: The router managing the tabview.
-  ///   - onReselected: An optional closure invoked when the user taps the already-selected tab,
-  ///     after `popToRoot()` has been called. For child-view use cases, prefer observing
-  ///     `TabRouter.tabReselected` via ``onTabReselected(_:perform:)`` instead.
   /// - Returns: A binding that updates the tab and clears its navigation stack when reselected.
   ///
   /// ## Usage
@@ -32,8 +29,7 @@ public extension Binding where Value: TabRoute {
   /// ```
   @MainActor static func tabToRoot(
     for tab: Binding<Value>,
-    in router: BaseRouter,
-    onReselected: ((Value) -> Void)? = nil
+    in router: BaseRouter
   ) -> Binding<Value> {
     Binding(
       get: { tab.wrappedValue },
@@ -41,7 +37,6 @@ public extension Binding where Value: TabRoute {
         if tab.wrappedValue == $0 {
           router.find(tab: $0)?.popToRoot()
           router.tabReselected.send(AnyTabRoute(wrapped: $0))
-          onReselected?($0)
         } else {
           tab.wrappedValue = $0
           if let tabRouter = router as? TabRouter {

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -24,6 +24,12 @@ public class BaseRouter: ObservableObject, Identifiable {
   /// Publisher to know if a router is present or not
   let present: PassthroughSubject<(Bool, BaseRouter), Never>
 
+  /// Emits whenever the user taps the already-selected tab.
+  ///
+  /// Observe this publisher from any view using ``onTabReselected(_:perform:)``.
+  /// On routers not managed by a `TabRouter`, this subject never emits.
+  public let tabReselected = PassthroughSubject<AnyTabRoute, Never>()
+
   /// The parent router, if any. Used for hierarchical navigation structures.
   weak var parent: BaseRouter?
 

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -28,7 +28,7 @@ public class BaseRouter: ObservableObject, Identifiable {
   ///
   /// Observe this publisher from any view using ``onTabReselected(_:perform:)``.
   /// On routers not managed by a `TabRouter`, this subject never emits.
-  public let tabReselected = PassthroughSubject<AnyTabRoute, Never>()
+  let tabReselected = PassthroughSubject<AnyTabRoute, Never>()
 
   /// The parent router, if any. Used for hierarchical navigation structures.
   weak var parent: BaseRouter?

--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -118,6 +118,8 @@ extension Router: @preconcurrency RouterModel {
   }
 
   @MainActor public func popToRoot() {
+    guard !path.isEmpty else { return }
+
     path.removeAll()
     log(.action(.popToRoot))
   }

--- a/Sources/SwiftRouting/Router/TabRouter.swift
+++ b/Sources/SwiftRouting/Router/TabRouter.swift
@@ -5,6 +5,7 @@
 //  Created by Kevin Budain on 06/03/2025.
 //
 
+import Combine
 import Foundation
 import Observation
 
@@ -30,6 +31,12 @@ public final class TabRouter: BaseRouter, @unchecked Sendable {
   /// This property is updated when the user selects a tab or when
   /// `change(tab:)` is called programmatically.
   @Published var tab: AnyTabRoute
+
+  /// Emits whenever the user taps the already-selected tab.
+  ///
+  /// Observe this publisher from any child view using ``onTabReselected(_:perform:)``,
+  /// or directly via `.onReceive(tabRouter.tabReselected)`.
+  public let tabReselected = PassthroughSubject<AnyTabRoute, Never>()
 
   /// All child routers managed by this tab router.
   ///

--- a/Sources/SwiftRouting/Router/TabRouter.swift
+++ b/Sources/SwiftRouting/Router/TabRouter.swift
@@ -5,7 +5,6 @@
 //  Created by Kevin Budain on 06/03/2025.
 //
 
-import Combine
 import Foundation
 import Observation
 
@@ -31,12 +30,6 @@ public final class TabRouter: BaseRouter, @unchecked Sendable {
   /// This property is updated when the user selects a tab or when
   /// `change(tab:)` is called programmatically.
   @Published var tab: AnyTabRoute
-
-  /// Emits whenever the user taps the already-selected tab.
-  ///
-  /// Observe this publisher from any child view using ``onTabReselected(_:perform:)``,
-  /// or directly via `.onReceive(tabRouter.tabReselected)`.
-  public let tabReselected = PassthroughSubject<AnyTabRoute, Never>()
 
   /// All child routers managed by this tab router.
   ///

--- a/Sources/SwiftRouting/SwiftRouting.docc/Articles/TabNavigation.md
+++ b/Sources/SwiftRouting/SwiftRouting.docc/Articles/TabNavigation.md
@@ -188,6 +188,29 @@ Pass `nil` for the tab parameter to use the currently selected tab:
 tabRouter?.push(HomeRoute.detail(id: 42), in: nil)
 ```
 
+## Reacting to Tab Reselection
+
+Use the ``onTabReselected(_:perform:)`` modifier from any view inside a `RoutingTabView` to react to same-tab taps. The default `popToRoot` behavior always fires first; the handler is called after.
+
+```swift
+struct HomeView: View {
+    @ScrollViewProxy var scrollProxy
+
+    var body: some View {
+        ScrollView {
+            // ...
+        }
+        .onTabReselected(HomeTab.home) {
+            scrollProxy.scrollTo("top", anchor: .top)
+        }
+    }
+}
+```
+
+> Note:
+> ``onTabReselected(_:perform:)`` works with both `RoutingTabView` and native `TabView + .tabToRoot`.
+> The handler fires only when the reselected tab matches the tab you pass.
+
 ## Hiding the Tab Bar
 
 To hide the tab bar when pushing views, override `hideTabBarOnPush`:

--- a/Sources/SwiftRouting/View/RoutingTabView.swift
+++ b/Sources/SwiftRouting/View/RoutingTabView.swift
@@ -24,8 +24,8 @@ import SwiftUI
 /// ```
 ///
 /// ## TabToRoot Behavior
-/// - If the user taps on the currently selected tab, the navigation stack is reset by default.
-/// - Use ``onTabReselected(_:)`` to override this behavior with custom logic.
+/// - If the user taps on the currently selected tab, the navigation stack is reset.
+/// - To react to same-tab taps from any child view, use ``onTabReselected(_:perform:)``.
 ///
 /// ## Notes
 /// - You can still use `TabView` without `RoutingTabView` if `TabRouter` is not needed.
@@ -45,7 +45,6 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
   @Binding private var tab: Tab
   private let destination: Destination.Type
   private let content: (Destination.Type) -> Content
-  private var onTabReselectedAction: ((Tab) -> Void)?
 
   /// Initializes a `RoutingTabView` instance.
   ///
@@ -63,38 +62,11 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
     self.content = content
   }
 
-  /// Adds a handler called when the user taps the already-selected tab.
-  ///
-  /// Tapping the currently selected tab always pops the navigation stack to its root (`popToRoot`).
-  /// Use this modifier to add custom logic on top of that behavior, such as scrolling to the top
-  /// of a list or dismissing a presented screen.
-  ///
-  /// The closure receives the reselected tab as its argument and is always called on the main actor.
-  ///
-  /// ```swift
-  /// RoutingTabView(tab: $tab, destination: HomeRoute.self) { destination in
-  ///   RoutingView(tab: HomeTab.home, destination: destination, root: .page1)
-  ///   RoutingView(tab: HomeTab.user, destination: destination, root: .page2)
-  /// }
-  /// .onTabReselected { tab in
-  ///   scrollProxy.scrollTo(top, anchor: .top)
-  /// }
-  /// ```
-  ///
-  /// - Parameter action: A closure invoked with the reselected tab, after `popToRoot()` has been called.
-  /// - Returns: A `RoutingTabView` that calls `action` when the user taps the already-selected tab.
-  public func onTabReselected(_ action: @escaping (Tab) -> Void) -> Self {
-    var copy = self
-    copy.onTabReselectedAction = action
-    return copy
-  }
-
   public var body: some View {
     Wrapped(
       tabRouter: TabRouter(tab: tab, parent: parent),
       currentTab: $tab,
       destination: destination,
-      onTabReselectedAction: onTabReselectedAction,
       content: content
     )
   }
@@ -104,11 +76,10 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
     @StateObject var tabRouter: TabRouter
     @Binding var currentTab: Tab
     let destination: Destination.Type
-    let onTabReselectedAction: ((Tab) -> Void)?
     let content: (Destination.Type) -> Content
 
     public var body: some View {
-      TabView(selection: .tabToRoot(for: $currentTab, in: tabRouter, onReselected: onTabReselectedAction)) {
+      TabView(selection: .tabToRoot(for: $currentTab, in: tabRouter)) {
         content(destination)
         // TODO: Try to had RoutingView for each child
 //        _VariadicView.Tree(TabViewContainer(currentTab: tab, destination: destination)) {

--- a/Sources/SwiftRouting/View/RoutingTabView.swift
+++ b/Sources/SwiftRouting/View/RoutingTabView.swift
@@ -65,9 +65,9 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
 
   /// Adds a handler called when the user taps the already-selected tab.
   ///
-  /// By default, tapping the currently selected tab pops the navigation stack to its root
-  /// (`popToRoot`). Use this modifier to replace that behavior with custom logic, such as
-  /// scrolling to the top of a list or dismissing a presented screen.
+  /// Tapping the currently selected tab always pops the navigation stack to its root (`popToRoot`).
+  /// Use this modifier to add custom logic on top of that behavior, such as scrolling to the top
+  /// of a list or dismissing a presented screen.
   ///
   /// The closure receives the reselected tab as its argument and is always called on the main actor.
   ///
@@ -81,7 +81,7 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
   /// }
   /// ```
   ///
-  /// - Parameter action: A closure invoked with the reselected tab. Replaces the default `popToRoot()` behavior.
+  /// - Parameter action: A closure invoked with the reselected tab, after `popToRoot()` has been called.
   /// - Returns: A `RoutingTabView` that calls `action` when the user taps the already-selected tab.
   public func onTabReselected(_ action: @escaping (Tab) -> Void) -> Self {
     var copy = self

--- a/Sources/SwiftRouting/View/RoutingTabView.swift
+++ b/Sources/SwiftRouting/View/RoutingTabView.swift
@@ -24,7 +24,8 @@ import SwiftUI
 /// ```
 ///
 /// ## TabToRoot Behavior
-/// - If the user taps on the currently selected tab, the navigation stack is reset.
+/// - If the user taps on the currently selected tab, the navigation stack is reset by default.
+/// - Use ``onTabReselected(_:)`` to override this behavior with custom logic.
 ///
 /// ## Notes
 /// - You can still use `TabView` without `RoutingTabView` if `TabRouter` is not needed.
@@ -44,6 +45,7 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
   @Binding private var tab: Tab
   private let destination: Destination.Type
   private let content: (Destination.Type) -> Content
+  private var onTabReselectedAction: ((Tab) -> Void)?
 
   /// Initializes a `RoutingTabView` instance.
   ///
@@ -61,11 +63,38 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
     self.content = content
   }
 
+  /// Adds a handler called when the user taps the already-selected tab.
+  ///
+  /// By default, tapping the currently selected tab pops the navigation stack to its root
+  /// (`popToRoot`). Use this modifier to replace that behavior with custom logic, such as
+  /// scrolling to the top of a list or dismissing a presented screen.
+  ///
+  /// The closure receives the reselected tab as its argument and is always called on the main actor.
+  ///
+  /// ```swift
+  /// RoutingTabView(tab: $tab, destination: HomeRoute.self) { destination in
+  ///   RoutingView(tab: HomeTab.home, destination: destination, root: .page1)
+  ///   RoutingView(tab: HomeTab.user, destination: destination, root: .page2)
+  /// }
+  /// .onTabReselected { tab in
+  ///   scrollProxy.scrollTo(top, anchor: .top)
+  /// }
+  /// ```
+  ///
+  /// - Parameter action: A closure invoked with the reselected tab. Replaces the default `popToRoot()` behavior.
+  /// - Returns: A `RoutingTabView` that calls `action` when the user taps the already-selected tab.
+  public func onTabReselected(_ action: @escaping (Tab) -> Void) -> Self {
+    var copy = self
+    copy.onTabReselectedAction = action
+    return copy
+  }
+
   public var body: some View {
     Wrapped(
       tabRouter: TabRouter(tab: tab, parent: parent),
       currentTab: $tab,
       destination: destination,
+      onTabReselectedAction: onTabReselectedAction,
       content: content
     )
   }
@@ -75,10 +104,11 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
     @StateObject var tabRouter: TabRouter
     @Binding var currentTab: Tab
     let destination: Destination.Type
+    let onTabReselectedAction: ((Tab) -> Void)?
     let content: (Destination.Type) -> Content
 
     public var body: some View {
-      TabView(selection: .tabToRoot(for: $currentTab, in: tabRouter)) {
+      TabView(selection: .tabToRoot(for: $currentTab, in: tabRouter, onReselected: onTabReselectedAction)) {
         content(destination)
         // TODO: Try to had RoutingView for each child
 //        _VariadicView.Tree(TabViewContainer(currentTab: tab, destination: destination)) {
@@ -87,7 +117,7 @@ public struct RoutingTabView<Tab: TabRoute, Destination: RouteDestination, Conte
       }
       .environment(\.tabRouter, tabRouter)
       .onReceive(tabRouter.$tab) { [$currentTab] in
-        if let tab = $0.wrapped as? Tab {
+        if let tab = $0.wrapped as? Tab, tab != $currentTab.wrappedValue {
           $currentTab.wrappedValue = tab
         }
       }

--- a/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
+++ b/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
@@ -1,0 +1,57 @@
+//
+//  TabReselectedModifier.swift
+//  SwiftRouting
+//
+
+import Combine
+import SwiftUI
+
+private struct TabReselectedModifier<Tab: TabRoute>: ViewModifier {
+
+  @Environment(\.tabRouter) private var tabRouter
+  let tab: Tab
+  let action: () -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .onReceive(
+        tabRouter?.tabReselected.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+      ) { reselectedTab in
+        guard reselectedTab.wrapped as? Tab == tab else { return }
+        action()
+      }
+  }
+}
+
+public extension View {
+
+  /// Adds a handler called when the user taps the already-selected tab.
+  ///
+  /// Use this modifier from any view inside a `RoutingTabView` to react to same-tab taps,
+  /// without affecting the default `popToRoot` behavior (which still fires).
+  ///
+  /// The handler is only triggered when the reselected tab matches `tab`.
+  /// It is always called on the main actor, after `popToRoot()` has been applied.
+  ///
+  /// ```swift
+  /// struct HomeView: View {
+  ///   @ScrollViewProxy var scrollProxy
+  ///
+  ///   var body: some View {
+  ///     ScrollView {
+  ///       // ...
+  ///     }
+  ///     .onTabReselected(HomeTab.home) {
+  ///       scrollProxy.scrollTo("top", anchor: .top)
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - tab: The tab whose reselection should trigger `action`.
+  ///   - action: A closure called when `tab` is reselected. No-op if used outside a `RoutingTabView`.
+  func onTabReselected<Tab: TabRoute>(_ tab: Tab, perform action: @escaping () -> Void) -> some View {
+    modifier(TabReselectedModifier(tab: tab, action: action))
+  }
+}

--- a/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
+++ b/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
@@ -14,9 +14,8 @@ private struct TabReselectedModifier<Tab: TabRoute>: ViewModifier {
   let action: () -> Void
 
   func body(content: Content) -> some View {
-    let source: BaseRouter = tabRouter ?? router
-    return content
-      .onReceive(source.tabReselected) { reselectedTab in
+    content
+      .onReceive((tabRouter ?? router.parent ?? router).tabReselected) { reselectedTab in
         guard reselectedTab.wrapped as? Tab == tab else { return }
         action()
       }

--- a/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
+++ b/Sources/SwiftRouting/ViewModifier/TabReselectedModifier.swift
@@ -8,15 +8,15 @@ import SwiftUI
 
 private struct TabReselectedModifier<Tab: TabRoute>: ViewModifier {
 
+  @Environment(\.router) private var router
   @Environment(\.tabRouter) private var tabRouter
   let tab: Tab
   let action: () -> Void
 
   func body(content: Content) -> some View {
-    content
-      .onReceive(
-        tabRouter?.tabReselected.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
-      ) { reselectedTab in
+    let source: BaseRouter = tabRouter ?? router
+    return content
+      .onReceive(source.tabReselected) { reselectedTab in
         guard reselectedTab.wrapped as? Tab == tab else { return }
         action()
       }
@@ -50,7 +50,7 @@ public extension View {
   ///
   /// - Parameters:
   ///   - tab: The tab whose reselection should trigger `action`.
-  ///   - action: A closure called when `tab` is reselected. No-op if used outside a `RoutingTabView`.
+  ///   - action: A closure called when `tab` is reselected. No-op outside a `RoutingTabView`.
   func onTabReselected<Tab: TabRoute>(_ tab: Tab, perform action: @escaping () -> Void) -> some View {
     modifier(TabReselectedModifier(tab: tab, action: action))
   }


### PR DESCRIPTION
- Fix setter firing twice on tab change: guard onReceive to skip write when value already matches
- Add onReselected parameter to Binding.tabToRoot (default nil keeps popToRoot behavior)
- Add onTabReselected(_ action:) modifier on RoutingTabView to intercept same-tab taps