### PR TITLE
Add deepestRouter() to BaseRouter for deeplink dispatch

### DIFF
--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -48,6 +48,16 @@ public class BaseRouter: ObservableObject, Identifiable {
   /// A dictionary containing child routers, stored weakly to avoid retain cycles.
   var children: [UUID: WeakContainer<BaseRouter>] = [:]
 
+  /// The live child `Router` instances presented from this router.
+  ///
+  /// Children are held weakly, so this returns only routers that are still
+  /// alive. Exposed so callers can walk the presented router hierarchy from
+  /// outside the package — e.g. to find the deepest presented router and
+  /// present on top of the current stack rather than the root.
+  public var childRouters: [Router] {
+    children.values.compactMap { $0.value as? Router }
+  }
+
   /// Initializes a `BaseRouter` with a given configuration and an optional parent.
   ///
   /// - Parameters:

--- a/Sources/SwiftRouting/Router/BaseRouter.swift
+++ b/Sources/SwiftRouting/Router/BaseRouter.swift
@@ -48,14 +48,13 @@ public class BaseRouter: ObservableObject, Identifiable {
   /// A dictionary containing child routers, stored weakly to avoid retain cycles.
   var children: [UUID: WeakContainer<BaseRouter>] = [:]
 
-  /// The live child `Router` instances presented from this router.
+  /// Returns the deepest actively-presented child `Router`, or `self` if no child is currently presented.
   ///
-  /// Children are held weakly, so this returns only routers that are still
-  /// alive. Exposed so callers can walk the presented router hierarchy from
-  /// outside the package — e.g. to find the deepest presented router and
-  /// present on top of the current stack rather than the root.
-  public var childRouters: [Router] {
-    children.values.compactMap { $0.value as? Router }
+  /// Use this to resolve the frontmost router at fire-time, e.g. when dispatching a deeplink
+  /// from AppDelegate so that `terminate(Context)` propagates through the correct presenter.
+  @MainActor public func deepestRouter() -> Router? {
+    let liveChildren = children.values.compactMap { $0.value as? Router }
+    return liveChildren.last?.deepestRouter() ?? self as? Router
   }
 
   /// Initializes a `BaseRouter` with a given configuration and an optional parent.


### PR DESCRIPTION
## Why

When dispatching deeplinks from AppDelegate/SceneDelegate, the root router is always used as the presenter. This means `terminate(Context)` fires on the root router's context — the screen the user was actually on never receives the dismissal callback.

To fix this, the deeplink must be presented by the currently-active (deepest) router rather than the root, so that `terminate(Context)` propagates through the correct presenter chain.

## What

Adds `deepestRouter()` to `BaseRouter`:

```swift
/// Returns the deepest actively-presented child `Router`, or `self` if no child is currently presented.
///
/// Use this to resolve the frontmost router at fire-time, e.g. when dispatching a deeplink
/// from AppDelegate so that `terminate(Context)` propagates through the correct presenter.
@MainActor public func deepestRouter() -> Router? {
    let liveChildren = children.values.compactMap { $0.value as? Router }
    return liveChildren.last?.deepestRouter() ?? self as? Router
}
```

Usage from AppDelegate/SceneDelegate:

```swift
rootRouter.deepestRouter()?.handle(deeplink: route)
```

No behavior change to existing routers; purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)