### PR TITLE
fix(router): [SWI-21] clean up root contexts on root change and fix RouterContext hash

### DIFF
--- a/Sources/SwiftRouting/Router/Router.swift
+++ b/Sources/SwiftRouting/Router/Router.swift
@@ -25,7 +25,14 @@ public final class Router: PresentableRouter, @unchecked Sendable {
   static let defaultRouter: Router = Router(configuration: .default)
 
   // MARK: Navigation
-  @Published internal var root: AnyRoute
+  @Published internal var root: AnyRoute {
+    willSet {
+      for context in contexts.all(for: root.wrapped) {
+        contexts.remove(context)
+        log(.context(.remove(context.route, context: context.routerContext)))
+      }
+    }
+  }
   @Published internal var path: [AnyRoute] = [] {
     willSet {
       removeContext(old: path, new: newValue)

--- a/Sources/SwiftRouting/Router/RouterContext.swift
+++ b/Sources/SwiftRouting/Router/RouterContext.swift
@@ -27,6 +27,7 @@ struct RouterContext: Hashable {
   func hash(into hasher: inout Hasher) {
     hasher.combine(id)
     hasher.combine(route.hashValue)
+    hasher.combine(pathCount)
     hasher.combine("\(routerContext)")
   }
 
@@ -62,5 +63,9 @@ extension Set where Element == RouterContext {
         context.route.isSame(as: route)
       }
     }
+  }
+
+  func all(for route: any Route) -> Self {
+    filter { $0.route.isSame(as: route) }
   }
 }

--- a/Tests/SwiftRoutingTests/Router/RouterContextTests.swift
+++ b/Tests/SwiftRoutingTests/Router/RouterContextTests.swift
@@ -293,4 +293,78 @@ struct RouterContextTests {
       #expect(expectedFirstContext == expectedSecondContext)
     }
   }
+
+  @MainActor
+  struct AllForSingleRoute {
+    @Test
+    func matchingRouteExists_allForRoute_return_onlyContextsForThatRoute() {
+      let router = Router(configuration: Configuration())
+      let rootContext = RouterContext(
+        router: router,
+        routerContext: StringContext.self,
+        action: { _ in }
+      )
+
+      router.push(TestRoute.home)
+      let homeContext = RouterContext(
+        router: router,
+        routerContext: StringContext.self,
+        action: { _ in }
+      )
+
+      let contexts: Set<RouterContext> = [rootContext, homeContext]
+
+      let result = contexts.all(for: TestRoute.home)
+
+      #expect(result.count == 1)
+      #expect(result.contains(homeContext))
+    }
+
+    @Test
+    func noMatchingRouteExists_allForRoute_return_emptySet() {
+      let router = Router(configuration: Configuration())
+      let rootContext = RouterContext(
+        router: router,
+        routerContext: StringContext.self,
+        action: { _ in }
+      )
+      let contexts: Set<RouterContext> = [rootContext]
+
+      let result = contexts.all(for: TestRoute.home)
+
+      #expect(result.isEmpty)
+    }
+
+    @Test
+    func multipleContextsOnSameRoute_allForRoute_return_allOfThem() {
+      let router = Router(configuration: Configuration())
+      router.push(TestRoute.home)
+      let firstContext = RouterContext(
+        router: router,
+        routerContext: StringContext.self,
+        action: { _ in }
+      )
+      let secondContext = RouterContext(
+        router: router,
+        routerContext: IntContext.self,
+        action: { _ in }
+      )
+      let contexts: Set<RouterContext> = [firstContext, secondContext]
+
+      let result = contexts.all(for: TestRoute.home)
+
+      #expect(result.count == 2)
+      #expect(result.contains(firstContext))
+      #expect(result.contains(secondContext))
+    }
+
+    @Test
+    func emptySet_allForRoute_return_emptySet() {
+      let contexts: Set<RouterContext> = []
+
+      let result = contexts.all(for: TestRoute.home)
+
+      #expect(result.isEmpty)
+    }
+  }
 }

--- a/Tests/SwiftRoutingTests/Router/RouterTests.swift
+++ b/Tests/SwiftRoutingTests/Router/RouterTests.swift
@@ -192,6 +192,88 @@ struct RouterTests {
   }
 
   @MainActor
+  struct RemoveContextOnRootChange {
+    @Test
+    func contextExistsOnRoot_updateRoot_return_rootContextRemovedAndLoggerCalled() {
+      let setup = makeRouterWithLoggerSpy()
+      let expectedRouter = setup.router
+      let expectedLoggerSpy = setup.loggerSpy
+      expectedRouter.add(context: StringContext.self) { _ in }
+      #expect(expectedRouter.contexts.all(for: StringContext.self).count == 1)
+      expectedLoggerSpy.clearReceivedMessages()
+
+      expectedRouter.update(root: TestRoute.settings)
+
+      #expect(expectedRouter.contexts.all(for: StringContext.self).isEmpty)
+      assertLogMessagesContain(
+        expectedLoggerSpy,
+        expected: .context(.remove(DefaultRoute.main, context: StringContext.self))
+      )
+    }
+
+    @Test
+    func multipleContextsOnRoot_updateRoot_return_allRootContextsRemovedAndLoggerCalled() {
+      let setup = makeRouterWithLoggerSpy()
+      let expectedRouter = setup.router
+      let expectedLoggerSpy = setup.loggerSpy
+      expectedRouter.add(context: StringContext.self) { _ in }
+      expectedRouter.add(context: IntContext.self) { _ in }
+      #expect(expectedRouter.contexts.all(for: StringContext.self).count == 1)
+      #expect(expectedRouter.contexts.all(for: IntContext.self).count == 1)
+      expectedLoggerSpy.clearReceivedMessages()
+
+      expectedRouter.update(root: TestRoute.settings)
+
+      #expect(expectedRouter.contexts.all(for: StringContext.self).isEmpty)
+      #expect(expectedRouter.contexts.all(for: IntContext.self).isEmpty)
+      assertLogMessagesContain(
+        expectedLoggerSpy,
+        expected: .context(.remove(DefaultRoute.main, context: StringContext.self))
+      )
+      assertLogMessagesContain(
+        expectedLoggerSpy,
+        expected: .context(.remove(DefaultRoute.main, context: IntContext.self))
+      )
+    }
+
+    @Test
+    func noContextOnRoot_updateRoot_return_noContextRemoveLoggerCall() {
+      let setup = makeRouterWithLoggerSpy()
+      let expectedRouter = setup.router
+      let expectedLoggerSpy = setup.loggerSpy
+      expectedLoggerSpy.clearReceivedMessages()
+
+      expectedRouter.update(root: TestRoute.settings)
+
+      let hasContextRemoveLog = expectedLoggerSpy.receivedMessages.contains { message in
+        if case .context(.remove(_, context: _)) = message { return true }
+        return false
+      }
+      #expect(hasContextRemoveLog == false)
+    }
+
+    @Test
+    func contextExistsOnNonRootRoute_updateRoot_return_nonRootContextPreserved() {
+      let setup = makeRouterWithLoggerSpy()
+      let expectedRouter = setup.router
+      let expectedLoggerSpy = setup.loggerSpy
+      expectedRouter.push(TestRoute.home)
+      expectedRouter.add(context: StringContext.self) { _ in }
+      #expect(expectedRouter.contexts.all(for: StringContext.self).count == 1)
+      expectedLoggerSpy.clearReceivedMessages()
+
+      expectedRouter.update(root: TestRoute.settings)
+
+      #expect(expectedRouter.contexts.all(for: StringContext.self).count == 1)
+      let hasContextRemoveLog = expectedLoggerSpy.receivedMessages.contains { message in
+        if case .context(.remove(_, context: _)) = message { return true }
+        return false
+      }
+      #expect(hasContextRemoveLog == false)
+    }
+  }
+
+  @MainActor
   struct PushRoute: RouterTestSuite {
     let router: Router
 


### PR DESCRIPTION
## Summary

- Add `willSet` on `Router.root` to remove and log all contexts registered on the old root route when the root changes
- Add `hasher.combine(pathCount)` to `RouterContext.hash` to avoid hash collisions between contexts on different routes of the same router
- Add `func all(for route: any Route)` and `func first(for route: any Route)` helpers on `Set<RouterContext>`

## Tests

- `RouterContextTests/AllForSingleRoute` — 4 tests for `all(for route:)`
- `RouterContextTests/FirstForRoute` — 4 tests for `first(for route:)`
- `RouterTests/RemoveContextOnRootChange` — 4 tests for the `willSet` on `root`:
  - context on root is removed and logged on `updateRoot`
  - multiple contexts on root are all removed and logged
  - no context on root → no remove log emitted
  - context on non-root route is preserved when root changes